### PR TITLE
formatting: Fix code style and code style tests (bug 1897434)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,10 @@ RUN adduser --system --no-create-home app
 
 RUN mkdir /code
 COPY ./ /code
+
+RUN mkdir -p /code/.ruff_cache
+RUN chown -R app /code/.ruff_cache
+
 RUN pip install --upgrade pip
 
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,6 +1,6 @@
 line-length = 88
-select = ["C", "E", "F", "W", "B", "B9", "I"]
-ignore = ["B006", "B904", "C901", "E203", "E501"]
+lint.select = ["C", "E", "F", "W", "B", "B9", "I"]
+lint.ignore = ["B006", "B904", "C901", "E203", "E501"]
 exclude = [
     ".git",
     "__pycache__",
@@ -9,5 +9,5 @@ exclude = [
     "__pycache__",
 ]
 
-[isort]
+[lint.isort]
 split-on-trailing-comma = true

--- a/src/lando/api/legacy/api/uplift.py
+++ b/src/lando/api/legacy/api/uplift.py
@@ -5,6 +5,7 @@
 import logging
 
 from django.conf import settings
+
 from lando.api import auth
 from lando.api.legacy.decorators import require_phabricator_api_key
 from lando.api.legacy.phabricator import PhabricatorClient

--- a/src/lando/api/legacy/bmo.py
+++ b/src/lando/api/legacy/bmo.py
@@ -3,7 +3,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import requests
-
 from django.conf import settings
 
 

--- a/src/lando/api/legacy/cache.py
+++ b/src/lando/api/legacy/cache.py
@@ -6,11 +6,11 @@ from __future__ import annotations
 
 import logging
 
+from django.conf import settings
 from flask_caching import Cache
 from flask_caching.backends.rediscache import RedisCache
 from redis import RedisError
 
-from django.conf import settings
 from lando.api.legacy.redis import SuppressRedisFailure
 from lando.api.legacy.systems import Subsystem
 

--- a/src/lando/api/legacy/celery.py
+++ b/src/lando/api/legacy/celery.py
@@ -19,15 +19,15 @@ logger = logging.getLogger(__name__)
 
 
 # Set the default Django settings module for the 'celery' program.
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'lando.settings')
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "lando.settings")
 
-app = Celery('lando')
+app = Celery("lando")
 
 # Using a string here means the worker doesn't have to serialize
 # the configuration object to child processes.
 # - namespace='CELERY' means all celery-related configuration keys
 #   should have a `CELERY_` prefix.
-app.config_from_object('django.conf:settings', namespace='CELERY')
+app.config_from_object("django.conf:settings", namespace="CELERY")
 
 # Load task modules from all registered Django apps.
 app.autodiscover_tasks()

--- a/src/lando/api/legacy/decorators.py
+++ b/src/lando/api/legacy/decorators.py
@@ -7,6 +7,7 @@ from typing import (
 )
 
 from django.conf import settings
+
 from lando.api.legacy.phabricator import PhabricatorClient
 from lando.main.support import problem, request
 

--- a/src/lando/api/legacy/phabricator.py
+++ b/src/lando/api/legacy/phabricator.py
@@ -23,8 +23,8 @@ from typing import (
 )
 
 import requests
-
 from django.conf import settings
+
 from lando.api.legacy.systems import Subsystem
 
 logger = logging.getLogger(__name__)

--- a/src/lando/api/legacy/phabricator_patch.py
+++ b/src/lando/api/legacy/phabricator_patch.py
@@ -144,9 +144,11 @@ def serialize_patched_file(diff: dict, public_node: str) -> dict:
         "metadata": metadata,
         "oldPath": old_path,
         "currentPath": diff["filename"],
-        "awayPaths": [old_path]
-        if change_kind in (ChangeKind.COPY_HERE, ChangeKind.MOVE_HERE)
-        else [],
+        "awayPaths": (
+            [old_path]
+            if change_kind in (ChangeKind.COPY_HERE, ChangeKind.MOVE_HERE)
+            else []
+        ),
         "commitHash": public_node,
         "type": change_kind.value,
         "fileType": file_type.value,

--- a/src/lando/api/legacy/repos.py
+++ b/src/lando/api/legacy/repos.py
@@ -15,6 +15,7 @@ from dataclasses import (
 from typing import Optional
 
 from django.conf import settings
+
 from lando.api.legacy.systems import Subsystem
 
 logger = logging.getLogger(__name__)

--- a/src/lando/api/legacy/sentry.py
+++ b/src/lando/api/legacy/sentry.py
@@ -4,9 +4,9 @@
 import logging
 
 import sentry_sdk
+from django.conf import settings
 from sentry_sdk.integrations.django import DjangoIntegration
 
-from django.conf import settings
 from lando.api.legacy.systems import Subsystem
 
 logger = logging.getLogger(__name__)

--- a/src/lando/api/legacy/smtp.py
+++ b/src/lando/api/legacy/smtp.py
@@ -6,6 +6,7 @@ import smtplib
 from contextlib import contextmanager
 
 from django.conf import settings
+
 from lando.api.legacy.systems import Subsystem
 
 logger = logging.getLogger(__name__)

--- a/src/lando/api/legacy/tasks.py
+++ b/src/lando/api/legacy/tasks.py
@@ -7,6 +7,7 @@ import ssl
 from typing import Optional
 
 from django.conf import settings
+
 from lando.api.legacy.celery import celery
 from lando.api.legacy.email import make_failure_email
 from lando.api.legacy.phabricator import (

--- a/src/lando/api/legacy/treestatus.py
+++ b/src/lando/api/legacy/treestatus.py
@@ -5,8 +5,8 @@ import logging
 from json.decoder import JSONDecodeError
 
 import requests
-
 from django.conf import settings
+
 from lando.api.legacy.systems import Subsystem
 
 logger = logging.getLogger(__name__)

--- a/src/lando/api/legacy/ui.py
+++ b/src/lando/api/legacy/ui.py
@@ -8,6 +8,7 @@ import logging
 from urllib.parse import urlparse
 
 from django.conf import settings
+
 from lando.api.legacy.systems import Subsystem
 
 logger = logging.getLogger(__name__)

--- a/src/lando/api/legacy/uplift.py
+++ b/src/lando/api/legacy/uplift.py
@@ -12,12 +12,12 @@ from typing import (
 )
 
 import requests
+from django.conf import settings
 from packaging.version import (
     InvalidVersion,
     Version,
 )
 
-from django.conf import settings
 from lando.api.legacy import bmo
 from lando.api.legacy.phabricator import PhabricatorClient
 from lando.api.legacy.phabricator_patch import patch_to_changes
@@ -67,9 +67,9 @@ def get_uplift_request_form(revision: dict) -> Optional[str]:
     return bug
 
 
-#@cache.cached(
+# @cache.cached(
 #    key_prefix="uplift-repositories"
-#)
+# )
 def get_uplift_repositories(phab: PhabricatorClient) -> list:
     repos = phab.call_conduit(
         "diffusion.repository.search",

--- a/src/lando/api/legacy/workers/landing_worker.py
+++ b/src/lando/api/legacy/workers/landing_worker.py
@@ -283,9 +283,7 @@ class LandingWorker(Worker):
                     f"encountered while pulling from {repo_pull_info}"
                 )
                 logger.exception(message)
-                job.transition_status(
-                    LandingJobAction.DEFER, message=message
-                )
+                job.transition_status(LandingJobAction.DEFER, message=message)
 
                 # Try again, this is a temporary failure.
                 return False
@@ -316,9 +314,7 @@ class LandingWorker(Worker):
                         f"{str(exc)}"
                     )
                     logger.exception(message)
-                    job.transition_status(
-                        LandingJobAction.FAIL, message=message
-                    )
+                    job.transition_status(LandingJobAction.FAIL, message=message)
                     self.notify_user_of_landing_failure(job)
                     return True
                 except NoDiffStartLine:
@@ -377,9 +373,7 @@ class LandingWorker(Worker):
 
                     logger.exception(message)
 
-                    job.transition_status(
-                        LandingJobAction.FAIL, message=message
-                    )
+                    job.transition_status(LandingJobAction.FAIL, message=message)
                     self.notify_user_of_landing_failure(job)
                     return False
 
@@ -407,9 +401,7 @@ class LandingWorker(Worker):
                     f"encountered while pushing to {repo_push_info}"
                 )
                 logger.exception(message)
-                job.transition_status(
-                    LandingJobAction.DEFER, message=message
-                )
+                job.transition_status(LandingJobAction.DEFER, message=message)
                 return False  # Try again, this is a temporary failure.
             except Exception as e:
                 message = f"Unexpected error while pushing to {repo.push_path}.\n{e}"
@@ -421,9 +413,7 @@ class LandingWorker(Worker):
                 self.notify_user_of_landing_failure(job)
                 return True  # Do not try again, this is a permanent failure.
 
-        job.transition_status(
-            LandingJobAction.LAND, commit_id=commit_id
-        )
+        job.transition_status(LandingJobAction.LAND, commit_id=commit_id)
 
         mots_path = Path(hgrepo.path) / "mots.yaml"
         if mots_path.exists():

--- a/src/lando/api/tests/conftest.py
+++ b/src/lando/api/tests/conftest.py
@@ -529,7 +529,7 @@ def proxy_client(monkeypatch):
 
     class ProxyClient:
         def _handle__get__stacks__id(self, path):
-            revision_id = path.lstrip("/stacks/")
+            revision_id = path.removeprefix("/stacks/")
             json_response = legacy_api_stacks.get(revision_id)
             if isinstance(json_response, HttpResponse):
                 # In some cases, an actual response object is returned.
@@ -539,7 +539,7 @@ def proxy_client(monkeypatch):
             return MockResponse(json=json.loads(json.dumps(json_response)))
 
         def _handle__get__transplants__id(self, path):
-            stack_revision_id = path.lstrip("/transplants?stack_revision_id=")
+            stack_revision_id = path.removeprefix("/transplants?stack_revision_id=")
             result = legacy_api_transplants.get_list(
                 stack_revision_id=stack_revision_id
             )
@@ -575,7 +575,7 @@ def proxy_client(monkeypatch):
             )
 
         def _handle__put__landing_jobs__id(self, path, **kwargs):
-            job_id = int(path.lstrip("/landing_jobs/"))
+            job_id = int(path.removeprefix("/landing_jobs/"))
             json_response = legacy_api_landing_jobs.put(job_id, kwargs["json"])
             return MockResponse(json=json.loads(json.dumps(json_response)))
 

--- a/src/lando/api/tests/test_landing_job.py
+++ b/src/lando/api/tests/test_landing_job.py
@@ -140,7 +140,9 @@ def test_landing_job_acquire_job_job_queue_query(db):
         job.save()
     # Queue order should match the order the jobs were created in.
 
-    for qjob, job in zip(LandingJob.job_queue_query(repositories=[REPO_NAME]), jobs):
+    for qjob, job in zip(
+        LandingJob.job_queue_query(repositories=[REPO_NAME]), jobs, strict=False
+    ):
         assert qjob.id == job.id
 
     # Update the last job to be in progress and mark the middle job to be

--- a/src/lando/api/tests/test_try.py
+++ b/src/lando/api/tests/test_try.py
@@ -15,7 +15,6 @@ from lando.api.legacy.repos import SCM_LEVEL_1, Repo
 from lando.api.legacy.workers.landing_worker import LandingWorker
 from lando.main.models.landing_job import LandingJob, LandingJobStatus
 
-
 pytest.skip(allow_module_level=True)
 
 PATCH_DIFF = rb"""

--- a/src/lando/main/admin.py
+++ b/src/lando/main/admin.py
@@ -1,8 +1,8 @@
 from django.contrib import admin
 
+from lando.main.models.base import Repo, Worker
 from lando.main.models.landing_job import LandingJob
 from lando.main.models.revision import Revision
-from lando.main.models.base import Repo, Worker
 
 admin.site.register(LandingJob, admin.ModelAdmin)
 admin.site.register(Revision, admin.ModelAdmin)

--- a/src/lando/main/models/__init__.py
+++ b/src/lando/main/models/__init__.py
@@ -1,1 +1,1 @@
-from lando.main.models.configuration import ConfigurationVariable
+from lando.main.models.configuration import ConfigurationVariable  # noqa: F401

--- a/src/lando/main/models/base.py
+++ b/src/lando/main/models/base.py
@@ -1,17 +1,15 @@
 from __future__ import annotations
 
-from contextlib import ContextDecorator
 import logging
 import os
 import subprocess
 import tempfile
+from contextlib import ContextDecorator
 from pathlib import Path
 
-from django.db import models
-from django.db import connection
-from django.db import transaction
-
 from django.conf import settings
+from django.db import connection, models, transaction
+
 from lando.utils import GitPatchHelper
 
 logger = logging.getLogger(__name__)

--- a/src/lando/tests/test_formatting.py
+++ b/src/lando/tests/test_formatting.py
@@ -1,13 +1,12 @@
 """
 Code Style Tests.
 """
-import pytest
+
 import subprocess
 
 from lando.settings import LINT_PATHS
 
 
-@pytest.mark.skip(reason="Skip so that all tests pass for now. Re-enable once we're in a clean 'formatted' state.")
 def test_black():
     cmd = ("black", "--diff")
     output = subprocess.check_output(cmd + LINT_PATHS)
@@ -15,7 +14,6 @@ def test_black():
 
 
 
-@pytest.mark.skip(reason="Skip so that all tests pass for now. Re-enable once we're in a clean 'formatted' state.")
 def test_ruff():
     passed = []
     for lint_path in LINT_PATHS:

--- a/src/lando/utils/management/commands/tests.py
+++ b/src/lando/utils/management/commands/tests.py
@@ -1,8 +1,7 @@
-import subprocess
 import os
+import subprocess
 
 from django.conf import settings
-
 from django.core.management.base import BaseCommand, CommandError
 
 ROOT_DIR = settings.BASE_DIR.parent.parent


### PR DESCRIPTION
Also resolved the following warnings:
- `error: Failed to initialize cache at /.ruff_cache: Permission denied (os error 13)` by creating the directory and taking ownership of it in the Dockerfile.
- `warning: The top-level linter settings are deprecated in favour of their counterparts in the lint section. Please update the following options in code/ruff.toml:  - 'ignore' -> lint.ignore'  - 'select' -> 'lint.select'  - 'isort' -> 'lint.isort'` by making the suggested changes in the `ruff.toml`.

`test_ruff` and `test_black` are now both enabled and passing.