### PR TITLE
lando: Fix url pattern warning (bug 1870695)

### DIFF
--- a/src/lando/urls.py
+++ b/src/lando/urls.py
@@ -22,5 +22,5 @@ from lando.ui.legacy import revisions
 urlpatterns = [
     path("admin/", admin.site.urls),
     path("oidc/", include("mozilla_django_oidc.urls")),
-    path("/D<int:revision_id>/", revisions.Revision.as_view()),
+    path("D<int:revision_id>/", revisions.Revision.as_view()),
 ]


### PR DESCRIPTION
Without this change, the warning presented is:
`(urls.W002) Your URL pattern '/D<int:revision_id>/' has a route beginning with a '/'. Remove this slash as it is unnecessary. If this pattern is targeted in an include(), ensure the include() pattern has a trailing '/'.`