### PR TITLE
makefile: Add `lando makemigrations` command to the Makefile (bug 1897551)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,13 +10,14 @@ help:
 	@echo "usage: make <target>"
 	@echo
 	@echo "target is one of:"
-	@echo "    help      show this message and exit"
-	@echo "    build     build the docker image for lando"
-	@echo "    format    run ruff and black on source code"
-	@echo "    test      run the test suite"
-	@echo "    start     run the application"
-	@echo "    stop      stop the application"
-	@echo "    attach    attach for debugging (ctrl-p ctrl-q to detach)"
+	@echo "    help        show this message and exit"
+	@echo "    build       build the docker image for lando"
+	@echo "    format      run ruff and black on source code"
+	@echo "    test        run the test suite"
+	@echo "    migrations  generates migration files to reflect model changes in the database"
+	@echo "    start       run the application"
+	@echo "    stop        stop the application"
+	@echo "    attach      attach for debugging (ctrl-p ctrl-q to detach)"
 
 .PHONY: test
 test:
@@ -29,6 +30,10 @@ format:
 .PHONY: build 
 build:
 	docker-compose build
+
+.PHONY: migrations
+migrations:
+	docker-compose run lando lando makemigrations
 
 .PHONY: start
 start:


### PR DESCRIPTION
I also shifted the `help` output to follow the same style even with the longer `migrations` word in the list now.