### PR TITLE
makefile: Fix `make help` on Windows (bug 1897553)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,8 @@ DOCKER_COMPOSE := $(shell which docker-compose)
 
 .PHONY: help
 help:
-	@$(DOCKER) --version
-	@$(DOCKER_COMPOSE) --version
+	@"$(DOCKER)" --version
+	@"$(DOCKER_COMPOSE)" --version
 	@echo "usage: make <target>"
 	@echo
 	@echo "target is one of:"


### PR DESCRIPTION
We need to quote the calls to the `docker` and `docker-compose` executables, since their absolute paths can contain spaces on Windows.