### PR TITLE
lando: Fix `STATICFILES_DIRS` warning (bug 1897550)

### DIFF
--- a/src/lando/static_src/TEMPORARY_FILE
+++ b/src/lando/static_src/TEMPORARY_FILE
@@ -1,0 +1,3 @@
+This file exists just to make sure this directory exists.
+
+It can be removed once actual static files are added.


### PR DESCRIPTION
Added a temporary file to ensure the `src\lando\static_src` directory exists to remove the `STATICFILES_DIRS` warning.