### PR TITLE
static_files: clear `STATIC_ROOT` on `collectstatic` call (bug 1903648)

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -22,7 +22,7 @@ services:
     command: bash -c "
       lando generate_version_file &&
       lando migrate &&
-      lando collectstatic --no-input &&
+      lando collectstatic --clear --no-input &&
       uwsgi --ini /code/uwsgi.ini"
     volumes:
       - ./:/code


### PR DESCRIPTION
The `--clear` argument will ensure all stale static files are deleted.