### PR TITLE
utils: phabricator client changes (bug 1915633)

### DIFF
--- a/src/lando/api/legacy/api/stacks.py
+++ b/src/lando/api/legacy/api/stacks.py
@@ -5,7 +5,6 @@ from django.conf import settings
 from django.http import Http404, HttpRequest
 
 from lando.api.legacy.commit_message import format_commit_message
-from lando.api.legacy.phabricator import PhabricatorClient
 from lando.api.legacy.projects import (
     get_release_managers,
     get_sec_approval_project_phid,
@@ -38,6 +37,7 @@ from lando.api.legacy.users import user_search
 from lando.main.auth import require_phabricator_api_key
 from lando.main.models import Repo
 from lando.main.models.revision import Revision
+from lando.utils.phabricator import PhabricatorClient
 
 logger = logging.getLogger(__name__)
 

--- a/src/lando/api/legacy/api/transplants.py
+++ b/src/lando/api/legacy/api/transplants.py
@@ -10,7 +10,6 @@ from django.http import HttpRequest
 
 from lando.api.legacy.api.stacks import HTTP_404_STRING
 from lando.api.legacy.commit_message import format_commit_message
-from lando.api.legacy.phabricator import PhabricatorClient
 from lando.api.legacy.projects import (
     CHECKIN_PROJ_SLUG,
     get_checkin_project_phid,
@@ -61,6 +60,7 @@ from lando.main.models.landing_job import (
     add_revisions_to_job,
 )
 from lando.main.support import LegacyAPIException, problem
+from lando.utils.phabricator import PhabricatorClient
 from lando.utils.tasks import admin_remove_phab_project
 
 logger = logging.getLogger(__name__)

--- a/src/lando/api/legacy/api/uplift.py
+++ b/src/lando/api/legacy/api/uplift.py
@@ -1,6 +1,5 @@
 import logging
 
-from lando.api.legacy.phabricator import PhabricatorClient
 from lando.api.legacy.uplift import (
     create_uplift_revision,
     get_local_uplift_repo,
@@ -11,6 +10,7 @@ from lando.api.legacy.validation import revision_id_to_int
 from lando.main.auth import require_authenticated_user, require_phabricator_api_key
 from lando.main.models import Repo
 from lando.main.support import problem
+from lando.utils.phabricator import PhabricatorClient
 
 logger = logging.getLogger(__name__)
 

--- a/src/lando/api/legacy/hooks.py
+++ b/src/lando/api/legacy/hooks.py
@@ -10,11 +10,11 @@ from flask import (
     request,
 )
 
-from lando.api.legacy.phabricator import PhabricatorAPIException
 from lando.api.legacy.sentry import sentry_sdk
 from lando.api.legacy.treestatus import TreeStatusException
 from lando.main.models.configuration import ConfigurationKey, ConfigurationVariable
 from lando.main.support import FlaskApi, problem
+from lando.utils.phabricator import PhabricatorAPIException
 
 logger = logging.getLogger(__name__)
 request_logger = logging.getLogger("request.summary")

--- a/src/lando/api/legacy/projects.py
+++ b/src/lando/api/legacy/projects.py
@@ -3,7 +3,7 @@ from typing import Optional
 
 from django.core.cache import cache
 
-from lando.api.legacy.phabricator import PhabricatorClient, result_list_to_phid_dict
+from lando.utils.phabricator import PhabricatorClient, result_list_to_phid_dict
 
 logger = logging.getLogger(__name__)
 

--- a/src/lando/api/legacy/reviews.py
+++ b/src/lando/api/legacy/reviews.py
@@ -1,13 +1,13 @@
 import logging
 from collections import namedtuple
 
-from lando.api.legacy.phabricator import (
+from lando.api.legacy.projects import (
+    RELMAN_PROJECT_SLUG,
+)
+from lando.utils.phabricator import (
     PhabricatorClient,
     PhabricatorCommunicationException,
     ReviewerStatus,
-)
-from lando.api.legacy.projects import (
-    RELMAN_PROJECT_SLUG,
 )
 
 logger = logging.getLogger(__name__)

--- a/src/lando/api/legacy/revisions.py
+++ b/src/lando/api/legacy/revisions.py
@@ -7,14 +7,14 @@ from typing import (
     Optional,
 )
 
-from lando.api.legacy.phabricator import (
-    PhabricatorClient,
-    PhabricatorRevisionStatus,
-    ReviewerStatus,
-)
 from lando.api.legacy.reviews import get_collated_reviewers
 from lando.api.legacy.uplift import (
     stack_uplift_form_submitted,
+)
+from lando.utils.phabricator import (
+    PhabricatorClient,
+    PhabricatorRevisionStatus,
+    ReviewerStatus,
 )
 
 logger = logging.getLogger(__name__)

--- a/src/lando/api/legacy/stacks.py
+++ b/src/lando/api/legacy/stacks.py
@@ -12,12 +12,12 @@ from typing import (
 
 import networkx as nx
 
-from lando.api.legacy.phabricator import (
+from lando.main.models import Repo
+from lando.utils.phabricator import (
     PhabricatorClient,
     PhabricatorRevisionStatus,
     result_list_to_phid_dict,
 )
-from lando.main.models import Repo
 
 logger = logging.getLogger(__name__)
 

--- a/src/lando/api/legacy/transactions.py
+++ b/src/lando/api/legacy/transactions.py
@@ -6,7 +6,7 @@ from typing import (
     Optional,
 )
 
-from lando.api.legacy.phabricator import PhabricatorClient
+from lando.utils.phabricator import PhabricatorClient
 
 # Type for a Phabricator API Transaction returned by the transaction.search operation.
 Transaction = NewType("Transaction", dict)

--- a/src/lando/api/legacy/transplants.py
+++ b/src/lando/api/legacy/transplants.py
@@ -7,11 +7,6 @@ from datetime import datetime, timezone
 
 import requests
 
-from lando.api.legacy.phabricator import (
-    PhabricatorClient,
-    PhabricatorRevisionStatus,
-    ReviewerStatus,
-)
 from lando.api.legacy.reviews import calculate_review_extra_state, reviewer_identity
 from lando.api.legacy.revisions import (
     check_author_planned_changes,
@@ -28,6 +23,11 @@ from lando.main.models import Repo
 from lando.main.models.landing_job import LandingJob, LandingJobStatus
 from lando.main.models.revision import DiffWarning, DiffWarningStatus
 from lando.main.support import LegacyAPIException
+from lando.utils.phabricator import (
+    PhabricatorClient,
+    PhabricatorRevisionStatus,
+    ReviewerStatus,
+)
 
 logger = logging.getLogger(__name__)
 

--- a/src/lando/api/legacy/uplift.py
+++ b/src/lando/api/legacy/uplift.py
@@ -14,7 +14,6 @@ from packaging.version import (
 )
 
 from lando.api.legacy import bmo
-from lando.api.legacy.phabricator import PhabricatorClient
 from lando.api.legacy.phabricator_patch import patch_to_changes
 from lando.api.legacy.stacks import (
     RevisionData,
@@ -23,6 +22,7 @@ from lando.api.legacy.stacks import (
     request_extended_revision_data,
 )
 from lando.main.models import Repo
+from lando.utils.phabricator import PhabricatorClient
 
 logger = logging.getLogger(__name__)
 

--- a/src/lando/api/legacy/users.py
+++ b/src/lando/api/legacy/users.py
@@ -1,4 +1,4 @@
-from lando.api.legacy.phabricator import result_list_to_phid_dict
+from lando.utils.phabricator import result_list_to_phid_dict
 
 
 def user_search(phabricator, user_phids):

--- a/src/lando/api/tests/conftest.py
+++ b/src/lando/api/tests/conftest.py
@@ -18,7 +18,6 @@ from django.test import Client
 import lando.api.legacy.api.landing_jobs as legacy_api_landing_jobs
 import lando.api.legacy.api.stacks as legacy_api_stacks
 import lando.api.legacy.api.transplants as legacy_api_transplants
-from lando.api.legacy.phabricator import PhabricatorClient
 from lando.api.legacy.projects import (
     CHECKIN_PROJ_SLUG,
     RELMAN_PROJECT_SLUG,
@@ -29,6 +28,7 @@ from lando.api.legacy.transplants import CODE_FREEZE_OFFSET, tokens_are_equal
 from lando.api.tests.mocks import PhabricatorDouble, TreeStatusDouble
 from lando.main.models import SCM_LEVEL_1, SCM_LEVEL_3, Repo
 from lando.main.support import LegacyAPIException
+from lando.utils.phabricator import PhabricatorClient
 
 PATCH_NORMAL_1 = r"""
 # HG changeset patch

--- a/src/lando/api/tests/mocks.py
+++ b/src/lando/api/tests/mocks.py
@@ -3,16 +3,16 @@ import json
 from collections import defaultdict
 from copy import deepcopy
 
-from lando.api.legacy.phabricator import (
-    PhabricatorAPIException,
-    PhabricatorClient,
-    PhabricatorRevisionStatus,
-    ReviewerStatus,
-)
 from lando.api.legacy.treestatus import TreeStatus, TreeStatusError
 from lando.api.tests.canned_responses.phabricator.diffs import (
     CANNED_DEFAULT_DIFF_CHANGES,
     CANNED_RAW_DEFAULT_DIFF,
+)
+from lando.utils.phabricator import (
+    PhabricatorAPIException,
+    PhabricatorClient,
+    PhabricatorRevisionStatus,
+    ReviewerStatus,
 )
 
 

--- a/src/lando/api/tests/test_hooks.py
+++ b/src/lando/api/tests/test_hooks.py
@@ -1,12 +1,12 @@
 import pytest
 
-from lando.api.legacy.phabricator import (
-    PhabricatorAPIException,
-    PhabricatorCommunicationException,
-)
 from lando.api.legacy.treestatus import (
     TreeStatusCommunicationException,
     TreeStatusError,
+)
+from lando.utils.phabricator import (
+    PhabricatorAPIException,
+    PhabricatorCommunicationException,
 )
 
 pytest.skip(allow_module_level=True)

--- a/src/lando/api/tests/test_phabricator.py
+++ b/src/lando/api/tests/test_phabricator.py
@@ -1,6 +1,6 @@
 import pytest
 
-from lando.api.legacy.phabricator import (
+from lando.utils.phabricator import (
     PhabricatorCommunicationException,
     PhabricatorRevisionStatus,
     result_list_to_phid_dict,

--- a/src/lando/api/tests/test_phabricator_client.py
+++ b/src/lando/api/tests/test_phabricator_client.py
@@ -6,8 +6,8 @@ import pytest
 import requests
 import requests_mock
 
-from lando.api.legacy.phabricator import PhabricatorAPIException
 from lando.api.tests.utils import phab_url
+from lando.utils.phabricator import PhabricatorAPIException
 
 pytestmark = pytest.mark.usefixtures("docker_env_vars")
 

--- a/src/lando/api/tests/test_reviews.py
+++ b/src/lando/api/tests/test_reviews.py
@@ -1,6 +1,5 @@
 import pytest
 
-from lando.api.legacy.phabricator import PhabricatorCommunicationException
 from lando.api.legacy.projects import project_search
 from lando.api.legacy.reviews import (
     approvals_for_commit_message,
@@ -9,6 +8,7 @@ from lando.api.legacy.reviews import (
     reviewers_for_commit_message,
 )
 from lando.api.legacy.users import user_search
+from lando.utils.phabricator import PhabricatorCommunicationException
 
 
 def test_collate_reviewer_attachments_malformed_raises():

--- a/src/lando/api/tests/test_revisions.py
+++ b/src/lando/api/tests/test_revisions.py
@@ -1,6 +1,5 @@
 import pytest
 
-from lando.api.legacy.phabricator import PhabricatorRevisionStatus, ReviewerStatus
 from lando.api.legacy.revisions import (
     check_author_planned_changes,
     check_diff_author_is_known,
@@ -12,6 +11,7 @@ from lando.api.legacy.stacks import (
     request_extended_revision_data,
 )
 from lando.main.models import Repo
+from lando.utils.phabricator import PhabricatorRevisionStatus, ReviewerStatus
 
 pytestmark = pytest.mark.usefixtures("docker_env_vars")
 

--- a/src/lando/api/tests/test_stacks.py
+++ b/src/lando/api/tests/test_stacks.py
@@ -1,7 +1,6 @@
 import pytest
 from django.http import Http404
 
-from lando.api.legacy.phabricator import PhabricatorRevisionStatus
 from lando.api.legacy.stacks import (
     RevisionStack,
     build_stack_graph,
@@ -10,6 +9,7 @@ from lando.api.legacy.stacks import (
     request_extended_revision_data,
 )
 from lando.main.models import Repo
+from lando.utils.phabricator import PhabricatorRevisionStatus
 
 
 def test_build_stack_graph_single_node(phabdouble):

--- a/src/lando/api/tests/test_tasks.py
+++ b/src/lando/api/tests/test_tasks.py
@@ -1,6 +1,6 @@
 import pytest
 
-from lando.api.legacy.phabricator import (
+from lando.utils.phabricator import (
     PhabricatorAPIException,
     PhabricatorCommunicationException,
 )

--- a/src/lando/api/tests/test_transplants.py
+++ b/src/lando/api/tests/test_transplants.py
@@ -3,7 +3,6 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from lando.api.legacy.phabricator import PhabricatorRevisionStatus, ReviewerStatus
 from lando.api.legacy.reviews import get_collated_reviewers
 from lando.api.legacy.transplants import (
     RevisionWarning,
@@ -22,6 +21,7 @@ from lando.main.models.landing_job import (
     add_job_with_revisions,
 )
 from lando.main.models.revision import Revision
+from lando.utils.phabricator import PhabricatorRevisionStatus, ReviewerStatus
 from lando.utils.tasks import admin_remove_phab_project
 
 

--- a/src/lando/api/tests/test_uplift.py
+++ b/src/lando/api/tests/test_uplift.py
@@ -3,9 +3,6 @@ from packaging.version import (
     Version,
 )
 
-from lando.api.legacy.phabricator import (
-    PhabricatorClient,
-)
 from lando.api.legacy.stacks import (
     build_stack_graph,
 )
@@ -15,6 +12,9 @@ from lando.api.legacy.uplift import (
     get_revisions_without_bugs,
     parse_milestone_version,
     strip_depends_on_from_commit_message,
+)
+from lando.utils.phabricator import (
+    PhabricatorClient,
 )
 
 MILESTONE_TEST_CONTENTS_1 = """

--- a/src/lando/main/auth.py
+++ b/src/lando/main/auth.py
@@ -8,8 +8,8 @@ from django.contrib.auth.models import User
 from django.http import HttpResponse
 from mozilla_django_oidc.auth import OIDCAuthenticationBackend
 
-from lando.api.legacy.phabricator import PhabricatorClient
 from lando.main.models.profile import Profile
+from lando.utils.phabricator import PhabricatorClient
 
 
 class LandoOIDCAuthenticationBackend(OIDCAuthenticationBackend):

--- a/src/lando/main/tests/__init__.py
+++ b/src/lando/main/tests/__init__.py
@@ -4,9 +4,9 @@ import pytest
 from django.contrib.auth.models import User
 from django.http import HttpResponse
 
-from lando.api.legacy.phabricator import PhabricatorClient
 from lando.main.auth import LandoOIDCAuthenticationBackend, require_phabricator_api_key
 from lando.main.models.profile import CLAIM_GROUPS_KEY
+from lando.utils.phabricator import PhabricatorClient
 
 
 @pytest.mark.parametrize(

--- a/src/lando/utils/apps.py
+++ b/src/lando/utils/apps.py
@@ -8,6 +8,10 @@ from lando.utils.phabricator import PhabricatorAPIException, PhabricatorClient
 
 PHAB_API_KEY_RE = re.compile(r"^api-.{28}$")
 
+PHAB_API_KEY_FORMAT_ERROR_TEMPLATE = (
+    '{} has the wrong format it must begin with "api-" and be 32 characters long.'
+)
+
 
 class UtilsConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
@@ -19,32 +23,34 @@ def phabricator_check(**kwargs) -> list[Error]:
     """Check validity of Phabricator settings and check connectivity."""
     errors = []
 
-    unpriv_key = settings.PHABRICATOR_UNPRIVILEGED_API_KEY
-    priv_key = settings.PHABRICATOR_ADMIN_API_KEY
+    unprivileged_key = settings.PHABRICATOR_UNPRIVILEGED_API_KEY
+    admin_key = settings.PHABRICATOR_ADMIN_API_KEY
 
-    if unpriv_key and PHAB_API_KEY_RE.search(unpriv_key) is None:
+    if unprivileged_key and PHAB_API_KEY_RE.search(unprivileged_key) is None:
         errors.append(
-            "PHABRICATOR_UNPRIVILEGED_API_KEY has the wrong format, "
-            'it must begin with "api-" and be 32 characters long.'
+            PHAB_API_KEY_FORMAT_ERROR_TEMPLATE.format(
+                "PHABRICATOR_UNPRIVILEGED_API_KEY"
+            )
         )
 
-    if priv_key and PHAB_API_KEY_RE.search(priv_key) is None:
+    if admin_key and PHAB_API_KEY_RE.search(admin_key) is None:
         errors.append(
-            "PHABRICATOR_ADMIN_API_KEY has the wrong format, "
-            'it must begin with "api-" and be 32 characters long.'
+            PHAB_API_KEY_FORMAT_ERROR_TEMPLATE.format("PHABRICATOR_ADMIN_API_KEY")
         )
 
-    if (unpriv_key or priv_key) and not errors:
-        if unpriv_key:
+    if (unprivileged_key or admin_key) and not errors:
+        if unprivileged_key:
             try:
                 PhabricatorClient(
                     settings.PHABRICATOR_URL,
                     settings.PHABRICATOR_UNPRIVILEGED_API_KEY,
                 ).call_conduit("conduit.ping")
             except PhabricatorAPIException as e:
-                errors.append(f"PhabricatorAPIException: {e!s} (using unpriviledged key)")
+                errors.append(
+                    f"PhabricatorAPIException: {e!s} (using unpriviledged key)"
+                )
 
-        if priv_key:
+        if admin_key:
             try:
                 PhabricatorClient(
                     settings.PHABRICATOR_URL,

--- a/src/lando/utils/apps.py
+++ b/src/lando/utils/apps.py
@@ -1,6 +1,46 @@
+import re
+
 from django.apps import AppConfig
+from django.conf import settings
+from django.core.checks import Error, register
+
+from lando.utils.phabricator import PhabricatorAPIException, PhabricatorClient
+
+PHAB_API_KEY_RE = re.compile(r"^api-.{28}$")
 
 
 class UtilsConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "lando.utils"
+
+
+@register()
+def phabricator_check(**kwargs):
+    """Check validity of Phabricator settings and check connectivity."""
+    errors = []
+
+    unpriv_key = settings.PHABRICATOR_UNPRIVILEGED_API_KEY
+    priv_key = settings.PHABRICATOR_ADMIN_API_KEY
+
+    if unpriv_key and PHAB_API_KEY_RE.search(unpriv_key) is None:
+        errors.append(
+            "PHABRICATOR_UNPRIVILEGED_API_KEY has the wrong format, "
+            'it must begin with "api-" and be 32 characters long.'
+        )
+
+    if priv_key and PHAB_API_KEY_RE.search(priv_key) is None:
+        errors.append(
+            "PHABRICATOR_ADMIN_API_KEY has the wrong format, "
+            'it must begin with "api-" and be 32 characters long.'
+        )
+
+    if (priv_key or unpriv_key) and not errors:
+        try:
+            PhabricatorClient(
+                settings.PHABRICATOR_URL,
+                settings.PHABRICATOR_UNPRIVILEGED_API_KEY,
+            ).call_conduit("conduit.ping")
+        except PhabricatorAPIException as e:
+            errors.append(f"PhabricatorAPIException: {e!s}")
+
+    return [Error(message) for message in errors]

--- a/src/lando/utils/tasks.py
+++ b/src/lando/utils/tasks.py
@@ -7,11 +7,11 @@ from django.conf import settings
 from django.core import mail
 
 from lando.api.legacy.email import make_failure_email
-from lando.api.legacy.phabricator import (
+from lando.utils.celery import app as celery_app
+from lando.utils.phabricator import (
     PhabricatorClient,
     PhabricatorCommunicationException,
 )
-from lando.utils.celery import app as celery_app
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
- add phabricator check to replace legacy health check
- check unprivileged and admin keys for validity
- remove phabricator subsystem
- move relevant functionality to lando.utils.phabricator
- update imports
- add get_phabricator_client method