### PR TITLE
sentry: only load version information for remote interaction (bug 1920808)

### DIFF
--- a/src/lando/main/sentry.py
+++ b/src/lando/main/sentry.py
@@ -4,8 +4,6 @@ import sentry_sdk
 from django.conf import settings
 from sentry_sdk.integrations.django import DjangoIntegration
 
-from lando.version import version
-
 logger = logging.getLogger(__name__)
 
 
@@ -13,6 +11,8 @@ def init_sentry():
     """Initialize Sentry integration for remote environments."""
     if not settings.ENVIRONMENT.is_remote:
         return
+
+    from lando.version import version
 
     sentry_sdk.init(
         dsn=settings.SENTRY_DSN,


### PR DESCRIPTION
This fixes a race where the version file generator cannot run because the version file is missing.