### PR TITLE
middleware: add response headers middleware (bug 1927148)

### DIFF
--- a/src/lando/middleware.py
+++ b/src/lando/middleware.py
@@ -1,3 +1,5 @@
+from collections.abc import Callable
+
 from django.conf import settings
 from django.http import HttpRequest, HttpResponse
 
@@ -5,7 +7,7 @@ from django.http import HttpRequest, HttpResponse
 class ResponseHeadersMiddleware:
     """Add custom response headers for each request."""
 
-    def __init__(self, get_response: callable):
+    def __init__(self, get_response: Callable[[HttpRequest], HttpResponse]):
         self.get_response = get_response
 
     def __call__(self, request: HttpRequest) -> HttpResponse:

--- a/src/lando/middleware.py
+++ b/src/lando/middleware.py
@@ -21,16 +21,16 @@ class ResponseHeadersMiddleware:
 
         csp = [
             "default-src 'self'",
-            "font-src 'self' https://code.cdn.mozilla.net",
-            "style-src 'self' https://code.cdn.mozilla.net",
-            "img-src 'self' *.cloudfront.net *.gravatar.com *.googleusercontent.com",
-            "object-src 'none'",
-            "frame-ancestors 'none'",
-            "manifest-src 'none'",
-            "worker-src 'none'",
-            "media-src 'none'",
-            "frame-src 'none'",
             "base-uri 'none'",
+            "font-src 'self' https://code.cdn.mozilla.net",
+            "frame-ancestors 'none'",
+            "frame-src 'none'",
+            "img-src 'self' *.cloudfront.net *.gravatar.com *.googleusercontent.com",
+            "manifest-src 'none'",
+            "media-src 'none'",
+            "object-src 'none'",
+            "style-src 'self' https://code.cdn.mozilla.net",
+            "worker-src 'none'",
         ]
 
         report_uri = settings.CSP_REPORTING_URL

--- a/src/lando/middleware.py
+++ b/src/lando/middleware.py
@@ -1,0 +1,41 @@
+from django.conf import settings
+from django.http import HttpRequest, HttpResponse
+
+
+class ResponseHeadersMiddleware:
+    """Add custom response headers for each request."""
+
+    def __init__(self, get_response: callable):
+        self.get_response = get_response
+
+    def __call__(self, request: HttpRequest) -> HttpResponse:
+        # NOTE: These headers were ported from both the legacy UI and API.
+        # API specific CSP headers should be implemented as part of bug 1927163.
+
+        response = self.get_response(request)
+
+        response["X-Frame-Options"] = "DENY"
+        response["X-Content-Type-Options"] = "nosniff"
+
+        csp = [
+            "default-src 'self'",
+            "font-src 'self' https://code.cdn.mozilla.net",
+            "style-src 'self' https://code.cdn.mozilla.net",
+            "img-src 'self' *.cloudfront.net *.gravatar.com *.googleusercontent.com",
+            "object-src 'none'",
+            "frame-ancestors 'none'",
+            "manifest-src 'none'",
+            "worker-src 'none'",
+            "media-src 'none'",
+            "frame-src 'none'",
+            "base-uri 'none'",
+        ]
+
+        report_uri = settings.CSP_REPORTING_URL
+
+        if report_uri:
+            csp.append("report-uri {}".format(report_uri))
+
+        response["Content-Security-Policy"] = "; ".join(csp)
+
+        return response

--- a/src/lando/settings.py
+++ b/src/lando/settings.py
@@ -63,6 +63,7 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "mozilla_django_oidc.middleware.SessionRefresh",
+    "lando.middleware.ResponseHeadersMiddleware",
 ]
 
 ROOT_URLCONF = "lando.urls"
@@ -213,6 +214,8 @@ CELERY_ACCEPT_CONTENT = ["json"]
 CELERY_TASK_SERIALIZER = "json"
 
 DEFAULT_FROM_EMAIL = "Lando <lando@lando.test>"
+
+CSP_REPORTING_URL = os.getenv("CSP_REPORTING_URL", "")
 
 if ENVIRONMENT.is_remote:
     STORAGES = {

--- a/src/lando/ui/tests/test_csp.py
+++ b/src/lando/ui/tests/test_csp.py
@@ -1,11 +1,5 @@
-import pytest
-
-# See bug 1926964.
-pytest.skip(allow_module_level=True)
-
-
 def test_csp_headers_set(client):
-    response = client.get("/")
+    response = client.get("/__version__")
     assert "Content-Security-Policy" in response.headers
     # Ensure we're using the most secure source by default
     assert "default-src 'self'" in response.headers["Content-Security-Policy"]


### PR DESCRIPTION
- port app wide headers hook (from legacy UI and API)
- re-enable previously skipped test (bug 1926964)
- remove some legacy code
- add failing test to account for future functionality