### PR TITLE
commands.test: add support for -k option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 SHELL := /bin/bash
 DOCKER := $(shell which docker)
 DOCKER_COMPOSE := $(shell which docker-compose)
+ARGS_TEST ?=
 
 ifeq ($(STANDALONE), 1)
 	BASE_COMMAND := docker-compose run lando
@@ -23,7 +24,7 @@ help:
 
 .PHONY: test
 test:
-	$(BASE_COMMAND) lando tests
+	$(BASE_COMMAND) lando tests $(ARGS_TESTS)
 
 .PHONY: format 
 format:

--- a/src/lando/utils/management/commands/tests.py
+++ b/src/lando/utils/management/commands/tests.py
@@ -22,8 +22,16 @@ class Command(BaseCommand):
             "paths", nargs="*", type=str, help="Files or directories to pass to pytest"
         )
 
+        parser.add_argument(
+            "-k", type=str, help="Only run tests which match the given substring."
+        )
+
     def handle(self, *args, **options):
         command = ["pytest"]
+
+        if options["k"]:
+            command.append("-k")
+            command.append(options["k"])
 
         if options["exitfirst"]:
             command.append("-x")


### PR DESCRIPTION
This allows to run only a subset of the tests.