### PR TITLE
landing_worker: fix handling of merge conflicts (bug 1938162) (bug 1935549)

### DIFF
--- a/src/lando/api/legacy/spec/swagger.yml
+++ b/src/lando/api/legacy/spec/swagger.yml
@@ -1,4 +1,4 @@
-swagger: '2.0'
+swagger: "2.0"
 info:
   title: Lando API
   description: An API to get and land Phabricator revisions.
@@ -31,17 +31,17 @@ paths:
           required: true
           in: body
           schema:
-            $ref: '#/definitions/TransplantRequest'
+            $ref: "#/definitions/TransplantRequest"
       responses:
         200:
           description: OK
           schema:
-            $ref: '#/definitions/TransplantAssessment'
+            $ref: "#/definitions/TransplantAssessment"
         default:
           description: Unexpected error
           schema:
             allOf:
-              - $ref: '#/definitions/Error'
+              - $ref: "#/definitions/Error"
   /transplants:
     get:
       operationId: landoapi.api.transplants.get_list
@@ -59,12 +59,12 @@ paths:
           schema:
             type: array
             items:
-              $ref: '#/definitions/Transplant'
+              $ref: "#/definitions/Transplant"
         default:
           description: Unexpected error
           schema:
             allOf:
-              - $ref: '#/definitions/Error'
+              - $ref: "#/definitions/Error"
     post:
       description: |
         Sends request to transplant service. If a Phabricator API
@@ -77,7 +77,7 @@ paths:
           in: body
           schema:
             allOf:
-              - $ref: '#/definitions/TransplantRequest'
+              - $ref: "#/definitions/TransplantRequest"
               - type: object
                 properties:
                   confirmation_token:
@@ -109,13 +109,13 @@ paths:
           description: Blockers or Unacknowledged Warnings
           schema:
             allOf:
-              - $ref: '#/definitions/Error'
-              - $ref: '#/definitions/TransplantAssessment'
+              - $ref: "#/definitions/Error"
+              - $ref: "#/definitions/TransplantAssessment"
         default:
           description: Error
           schema:
             allOf:
-              - $ref: '#/definitions/Error'
+              - $ref: "#/definitions/Error"
   /diff_warnings/{pk}:
     delete:
       operationId: landoapi.api.diff_warnings.delete
@@ -143,7 +143,7 @@ paths:
       operationId: landoapi.api.diff_warnings.get
       description: Gets a list of diff warnings based on provided filters
       parameters:
-        - name: revision_id 
+        - name: revision_id
           in: query
           required: true
           type: integer
@@ -164,7 +164,7 @@ paths:
       operationId: landoapi.api.diff_warnings.post
       description: Creates a new diff warning
       parameters:
-        - name: data 
+        - name: data
           in: body
           required: true
           schema:
@@ -226,17 +226,17 @@ paths:
           description: Service not authorized
           schema:
             allOf:
-              - $ref: '#/definitions/Error'
+              - $ref: "#/definitions/Error"
         404:
           description: Landing job does not exist
           schema:
             allOf:
-              - $ref: '#/definitions/Error'
+              - $ref: "#/definitions/Error"
         default:
           description: Unexpected error
           schema:
             allOf:
-              - $ref: '#/definitions/Error'
+              - $ref: "#/definitions/Error"
   /stacks/{revision_id}:
     get:
       description: |
@@ -252,12 +252,12 @@ paths:
         200:
           description: OK
           schema:
-            $ref: '#/definitions/Stack'
+            $ref: "#/definitions/Stack"
         default:
           description: Unexpected error
           schema:
             allOf:
-              - $ref: '#/definitions/Error'
+              - $ref: "#/definitions/Error"
   /requestSecApproval:
     post:
       operationId: landoapi.api.revisions.request_sec_approval
@@ -292,7 +292,7 @@ paths:
           description: Unexpected error
           schema:
             allOf:
-              - $ref: '#/definitions/Error'
+              - $ref: "#/definitions/Error"
   /uplift:
     get:
       operationId: landoapi.api.uplift.get
@@ -333,17 +333,17 @@ paths:
           description: Invalid payload
           schema:
             allOf:
-              - $ref: '#/definitions/Error'
+              - $ref: "#/definitions/Error"
         403:
           description: Service not authorized
           schema:
             allOf:
-              - $ref: '#/definitions/Error'
+              - $ref: "#/definitions/Error"
         default:
           description: Unexpected error
           schema:
             allOf:
-              - $ref: '#/definitions/Error'
+              - $ref: "#/definitions/Error"
   /try/patches:
     post:
       operationId: landoapi.api.try_push.post_patches
@@ -427,7 +427,7 @@ definitions:
       - landing_path
     properties:
       landing_path:
-        $ref: '#/definitions/LandingPath'
+        $ref: "#/definitions/LandingPath"
   Transplant:
     type: object
     properties:
@@ -445,9 +445,9 @@ definitions:
         description: |
           Status of the landing job in Autoland Transplant.
       landing_path:
-        $ref: '#/definitions/LandingPath'
+        $ref: "#/definitions/LandingPath"
       error_breakdown:
-        $ref: '#/definitions/ErrorBreakdown'
+        $ref: "#/definitions/ErrorBreakdown"
       details:
         type: string
         description: |
@@ -483,26 +483,26 @@ definitions:
         description: |
           A list of edges defining the stacks dependency graph.
         items:
-          $ref: '#/definitions/StackEdge'
+          $ref: "#/definitions/StackEdge"
       landable_paths:
         type: array
         description: |
           A list of landable paths through the stack graph.
         items:
-          $ref: '#/definitions/LandablePath'
+          $ref: "#/definitions/LandablePath"
       revisions:
         type: array
         description: |
           A list of revisions which are part of the stack.
         items:
-          $ref: '#/definitions/Revision'
+          $ref: "#/definitions/Revision"
       repositories:
         type: array
         description: |
           A list of all repositories that have revisions in the stack.
           Lando may not support landing to all of these repositories.
         items:
-          $ref: '#/definitions/Repository'
+          $ref: "#/definitions/Repository"
       uplift_repositories:
         type: array
         description: |
@@ -630,13 +630,13 @@ definitions:
         description: |
           The PHID of this revision's repository.
       diff:
-        $ref: '#/definitions/Diff'
+        $ref: "#/definitions/Diff"
       author:
-        $ref: '#/definitions/User'
+        $ref: "#/definitions/User"
       reviewers:
         type: array
         items:
-          $ref: '#/definitions/Reviewer'
+          $ref: "#/definitions/Reviewer"
       is_secure:
         type: boolean
         description: |

--- a/src/lando/api/legacy/spec/swagger.yml
+++ b/src/lando/api/legacy/spec/swagger.yml
@@ -416,7 +416,7 @@ definitions:
         description: List of paths that failed to merge.
         items:
           type: string
-      reject_paths:
+      rejects_paths:
         type: array
         description: List of names of .rej files.
         items:

--- a/src/lando/api/legacy/spec/swagger.yml
+++ b/src/lando/api/legacy/spec/swagger.yml
@@ -1,4 +1,4 @@
-swagger: "2.0"
+swagger: '2.0'
 info:
   title: Lando API
   description: An API to get and land Phabricator revisions.
@@ -31,17 +31,17 @@ paths:
           required: true
           in: body
           schema:
-            $ref: "#/definitions/TransplantRequest"
+            $ref: '#/definitions/TransplantRequest'
       responses:
         200:
           description: OK
           schema:
-            $ref: "#/definitions/TransplantAssessment"
+            $ref: '#/definitions/TransplantAssessment'
         default:
           description: Unexpected error
           schema:
             allOf:
-              - $ref: "#/definitions/Error"
+              - $ref: '#/definitions/Error'
   /transplants:
     get:
       operationId: landoapi.api.transplants.get_list
@@ -59,12 +59,12 @@ paths:
           schema:
             type: array
             items:
-              $ref: "#/definitions/Transplant"
+              $ref: '#/definitions/Transplant'
         default:
           description: Unexpected error
           schema:
             allOf:
-              - $ref: "#/definitions/Error"
+              - $ref: '#/definitions/Error'
     post:
       description: |
         Sends request to transplant service. If a Phabricator API
@@ -77,7 +77,7 @@ paths:
           in: body
           schema:
             allOf:
-              - $ref: "#/definitions/TransplantRequest"
+              - $ref: '#/definitions/TransplantRequest'
               - type: object
                 properties:
                   confirmation_token:
@@ -109,13 +109,13 @@ paths:
           description: Blockers or Unacknowledged Warnings
           schema:
             allOf:
-              - $ref: "#/definitions/Error"
-              - $ref: "#/definitions/TransplantAssessment"
+              - $ref: '#/definitions/Error'
+              - $ref: '#/definitions/TransplantAssessment'
         default:
           description: Error
           schema:
             allOf:
-              - $ref: "#/definitions/Error"
+              - $ref: '#/definitions/Error'
   /diff_warnings/{pk}:
     delete:
       operationId: landoapi.api.diff_warnings.delete
@@ -143,7 +143,7 @@ paths:
       operationId: landoapi.api.diff_warnings.get
       description: Gets a list of diff warnings based on provided filters
       parameters:
-        - name: revision_id
+        - name: revision_id 
           in: query
           required: true
           type: integer
@@ -164,7 +164,7 @@ paths:
       operationId: landoapi.api.diff_warnings.post
       description: Creates a new diff warning
       parameters:
-        - name: data
+        - name: data 
           in: body
           required: true
           schema:
@@ -226,17 +226,17 @@ paths:
           description: Service not authorized
           schema:
             allOf:
-              - $ref: "#/definitions/Error"
+              - $ref: '#/definitions/Error'
         404:
           description: Landing job does not exist
           schema:
             allOf:
-              - $ref: "#/definitions/Error"
+              - $ref: '#/definitions/Error'
         default:
           description: Unexpected error
           schema:
             allOf:
-              - $ref: "#/definitions/Error"
+              - $ref: '#/definitions/Error'
   /stacks/{revision_id}:
     get:
       description: |
@@ -252,12 +252,12 @@ paths:
         200:
           description: OK
           schema:
-            $ref: "#/definitions/Stack"
+            $ref: '#/definitions/Stack'
         default:
           description: Unexpected error
           schema:
             allOf:
-              - $ref: "#/definitions/Error"
+              - $ref: '#/definitions/Error'
   /requestSecApproval:
     post:
       operationId: landoapi.api.revisions.request_sec_approval
@@ -292,7 +292,7 @@ paths:
           description: Unexpected error
           schema:
             allOf:
-              - $ref: "#/definitions/Error"
+              - $ref: '#/definitions/Error'
   /uplift:
     get:
       operationId: landoapi.api.uplift.get
@@ -333,17 +333,17 @@ paths:
           description: Invalid payload
           schema:
             allOf:
-              - $ref: "#/definitions/Error"
+              - $ref: '#/definitions/Error'
         403:
           description: Service not authorized
           schema:
             allOf:
-              - $ref: "#/definitions/Error"
+              - $ref: '#/definitions/Error'
         default:
           description: Unexpected error
           schema:
             allOf:
-              - $ref: "#/definitions/Error"
+              - $ref: '#/definitions/Error'
   /try/patches:
     post:
       operationId: landoapi.api.try_push.post_patches
@@ -427,7 +427,7 @@ definitions:
       - landing_path
     properties:
       landing_path:
-        $ref: "#/definitions/LandingPath"
+        $ref: '#/definitions/LandingPath'
   Transplant:
     type: object
     properties:
@@ -445,9 +445,9 @@ definitions:
         description: |
           Status of the landing job in Autoland Transplant.
       landing_path:
-        $ref: "#/definitions/LandingPath"
+        $ref: '#/definitions/LandingPath'
       error_breakdown:
-        $ref: "#/definitions/ErrorBreakdown"
+        $ref: '#/definitions/ErrorBreakdown'
       details:
         type: string
         description: |
@@ -483,26 +483,26 @@ definitions:
         description: |
           A list of edges defining the stacks dependency graph.
         items:
-          $ref: "#/definitions/StackEdge"
+          $ref: '#/definitions/StackEdge'
       landable_paths:
         type: array
         description: |
           A list of landable paths through the stack graph.
         items:
-          $ref: "#/definitions/LandablePath"
+          $ref: '#/definitions/LandablePath'
       revisions:
         type: array
         description: |
           A list of revisions which are part of the stack.
         items:
-          $ref: "#/definitions/Revision"
+          $ref: '#/definitions/Revision'
       repositories:
         type: array
         description: |
           A list of all repositories that have revisions in the stack.
           Lando may not support landing to all of these repositories.
         items:
-          $ref: "#/definitions/Repository"
+          $ref: '#/definitions/Repository'
       uplift_repositories:
         type: array
         description: |
@@ -630,13 +630,13 @@ definitions:
         description: |
           The PHID of this revision's repository.
       diff:
-        $ref: "#/definitions/Diff"
+        $ref: '#/definitions/Diff'
       author:
-        $ref: "#/definitions/User"
+        $ref: '#/definitions/User'
       reviewers:
         type: array
         items:
-          $ref: "#/definitions/Reviewer"
+          $ref: '#/definitions/Reviewer'
       is_secure:
         type: boolean
         description: |

--- a/src/lando/api/legacy/workers/landing_worker.py
+++ b/src/lando/api/legacy/workers/landing_worker.py
@@ -153,8 +153,8 @@ class LandingWorker(Worker):
         breakdown["failed_paths"] = [
             {
                 "path": path[0],
-                "url": f"{repo.pull_path}/file/{path[1].decode('utf-8')}/{path[0]}",
-                "changeset_id": path[1].decode("utf-8"),
+                "url": f"{repo.pull_path}/file/{path[1]}/{path[0]}",
+                "changeset_id": path[1],
             }
             for path in failed_path_changesets
         ]

--- a/src/lando/api/legacy/workers/landing_worker.py
+++ b/src/lando/api/legacy/workers/landing_worker.py
@@ -129,7 +129,6 @@ class LandingWorker(Worker):
             job.requester_email, job.landing_job_identifier, job.error, job.id
         )
 
-    # XXX Not covered by tests
     def process_merge_conflict(
         self,
         exception: PatchConflict,

--- a/src/lando/api/legacy/workers/landing_worker.py
+++ b/src/lando/api/legacy/workers/landing_worker.py
@@ -162,7 +162,7 @@ class LandingWorker(Worker):
         for path in reject_paths:
             reject = {"path": path}
             try:
-                with open(scm.REJECT_PATHS / repo.path[1:] / path, "r") as f:
+                with open(scm.reject_path() / repo.path[1:] / path, "r") as f:
                     reject["content"] = f.read()
             except Exception as e:
                 logger.exception(e)

--- a/src/lando/api/legacy/workers/landing_worker.py
+++ b/src/lando/api/legacy/workers/landing_worker.py
@@ -151,11 +151,11 @@ class LandingWorker(Worker):
 
         breakdown["failed_paths"] = [
             {
-                "path": path[0],
-                "url": f"{repo.pull_path}/file/{path[1]}/{path[0]}",
-                "changeset_id": path[1],
+                "path": path,
+                "url": f"{repo.pull_path}/file/{revision}/{path}",
+                "changeset_id": revision,
             }
-            for path in failed_path_changesets
+            for (path, revision) in failed_path_changesets
         ]
         breakdown["rejects_paths"] = {}
         for path in rejects_paths:

--- a/src/lando/api/legacy/workers/landing_worker.py
+++ b/src/lando/api/legacy/workers/landing_worker.py
@@ -146,7 +146,6 @@ class LandingWorker(Worker):
 
         breakdown = {
             "revision_id": revision_id,
-            "content": None,
             "reject_paths": None,
         }
 

--- a/src/lando/api/tests/test_landings.py
+++ b/src/lando/api/tests/test_landings.py
@@ -504,17 +504,17 @@ def test_merge_conflict(
     assert "hunks FAILED" in caplog.text
     assert job.error_breakdown, "No error breakdown added to job"
     assert job.error_breakdown.get(
-        "reject_paths"
+        "rejects_paths"
     ), "Empty or missing reject information in error breakdown"
     failed_paths = [p["path"] for p in job.error_breakdown["failed_paths"]]
     assert set(failed_paths) == set(
-        job.error_breakdown["reject_paths"].keys()
-    ), "Mismatch between failed_paths and reject_paths"
+        job.error_breakdown["rejects_paths"].keys()
+    ), "Mismatch between failed_paths and rejects_paths"
     for fp in failed_paths:
-        assert job.error_breakdown["reject_paths"][fp].get(
+        assert job.error_breakdown["rejects_paths"][fp].get(
             "path"
         ), f"Empty or missing reject path for failed path {fp}"
-        assert job.error_breakdown["reject_paths"][fp].get(
+        assert job.error_breakdown["rejects_paths"][fp].get(
             "content"
         ), f"Empty or missing reject content for failed path {fp}"
 

--- a/src/lando/main/models/landing_job.py
+++ b/src/lando/main/models/landing_job.py
@@ -76,7 +76,7 @@ class LandingJob(BaseModel):
     # Error details in a dictionary format, listing failed merges, etc...
     # E.g. {
     #    "failed_paths": [{"path": "...", "url": "..."}],
-    #    "reject_paths": [{"path": "...", "content": "..."}]
+    #    "rejects_paths": [{"path": "...", "content": "..."}]
     # }
     error_breakdown = models.JSONField(null=True, blank=True, default=dict)
 

--- a/src/lando/main/scm/abstract_scm.py
+++ b/src/lando/main/scm/abstract_scm.py
@@ -27,6 +27,11 @@ class AbstractSCM:
         """Return a _human-friendly_ string identifying the supported SCM (e.g.,
         `Mercurial`)."""
 
+    @classmethod
+    def reject_path(cls) -> Path:
+        """Return the path where the SCM stores reject files."""
+        return Path(".")
+
     @abstractmethod
     def clone(self, source: str):
         """Clone a repository from a source.

--- a/src/lando/main/scm/abstract_scm.py
+++ b/src/lando/main/scm/abstract_scm.py
@@ -29,7 +29,12 @@ class AbstractSCM:
 
     @classmethod
     def get_rejects_path(cls) -> Path:
-        """Return the path where the SCM stores reject files."""
+        """Return the path where the SCM stores reject files.
+
+        We assume most SCMs just use the local directory, and provide a default
+        implementation. This however allows SCMs whose behaviour differs, such as
+        Mercurial, to provide a path to where the rejects are stored.
+        """
         return Path(".")
 
     @abstractmethod

--- a/src/lando/main/scm/abstract_scm.py
+++ b/src/lando/main/scm/abstract_scm.py
@@ -28,7 +28,7 @@ class AbstractSCM:
         `Mercurial`)."""
 
     @classmethod
-    def reject_path(cls) -> Path:
+    def get_rejects_path(cls) -> Path:
         """Return the path where the SCM stores reject files."""
         return Path(".")
 

--- a/src/lando/main/scm/hg.py
+++ b/src/lando/main/scm/hg.py
@@ -181,8 +181,8 @@ class HgSCM(AbstractSCM):
         """Return a _human-friendly_ string identifying the supported SCM."""
         return "Mercurial"
 
-    @property
-    def REJECTS_PATH(self) -> Path:
+    @classmethod
+    def reject_path(cls) -> Path:
         """A Path where this SCM stores reject from a failed patch application."""
         return Path("/tmp/patch_rejects")
 
@@ -518,18 +518,18 @@ class HgSCM(AbstractSCM):
     def clean_repo(self, *, strip_non_public_commits: bool = True):
         """Clean the local working copy from all extraneous files."""
         # Reset rejects directory
-        if self.REJECTS_PATH.is_dir():
-            shutil.rmtree(self.REJECTS_PATH)
-        self.REJECTS_PATH.mkdir()
+        if self.reject_path().is_dir():
+            shutil.rmtree(self.reject_path())
+        self.reject_path().mkdir()
 
         # Copy .rej files to a temporary folder.
         rejects = Path(f"{self.path}/").rglob("*.rej")
         for reject in rejects:
             os.makedirs(
-                self.REJECTS_PATH.joinpath(reject.parents[0].as_posix()[1:]),
+                self.reject_path().joinpath(reject.parents[0].as_posix()[1:]),
                 exist_ok=True,
             )
-            shutil.copy(reject, self.REJECTS_PATH.joinpath(reject.as_posix()[1:]))
+            shutil.copy(reject, self.reject_path().joinpath(reject.as_posix()[1:]))
 
         # Clean working directory.
         try:

--- a/src/lando/main/scm/hg.py
+++ b/src/lando/main/scm/hg.py
@@ -182,7 +182,7 @@ class HgSCM(AbstractSCM):
         return "Mercurial"
 
     @classmethod
-    def reject_path(cls) -> Path:
+    def get_rejects_path(cls) -> Path:
         """A Path where this SCM stores reject from a failed patch application."""
         return Path("/tmp/patch_rejects")
 
@@ -518,18 +518,18 @@ class HgSCM(AbstractSCM):
     def clean_repo(self, *, strip_non_public_commits: bool = True):
         """Clean the local working copy from all extraneous files."""
         # Reset rejects directory
-        if self.reject_path().is_dir():
-            shutil.rmtree(self.reject_path())
-        self.reject_path().mkdir()
+        if self.get_rejects_path().is_dir():
+            shutil.rmtree(self.get_rejects_path())
+        self.get_rejects_path().mkdir()
 
         # Copy .rej files to a temporary folder.
         rejects = Path(f"{self.path}/").rglob("*.rej")
         for reject in rejects:
             os.makedirs(
-                self.reject_path().joinpath(reject.parents[0].as_posix()[1:]),
+                self.get_rejects_path().joinpath(reject.parents[0].as_posix()[1:]),
                 exist_ok=True,
             )
-            shutil.copy(reject, self.reject_path().joinpath(reject.as_posix()[1:]))
+            shutil.copy(reject, self.get_rejects_path().joinpath(reject.as_posix()[1:]))
 
         # Clean working directory.
         try:

--- a/src/lando/ui/jinja2/stack/partials/timeline.html
+++ b/src/lando/ui/jinja2/stack/partials/timeline.html
@@ -1,69 +1,73 @@
 <div class="StackPage-timeline">
-    {% if transplants %}
-    {%- for transplant in transplants|sort(attribute='updated_at', reverse=True) %}
-    <div class="StackPage-timeline-item">
-        <div class="StackPage-timeline-itemStatus">
-            <span class="{{ transplant|tostatusbadgeclass }}">{{transplant|tostatusbadgename}}</span>
-        </div>
+  {% if transplants %}
+  {%- for transplant in transplants|sort(attribute='updated_at', reverse=True) %}
+  <div class="StackPage-timeline-item">
+    <div class="StackPage-timeline-itemStatus">
+      <span class="{{ transplant|tostatusbadgeclass }}">{{transplant|tostatusbadgename}}</span>
+    </div>
 
-        <div class="StackPage-timeline-itemDetail">
-            <p>Landing requested on <time data-timestamp="{{ transplant['created_at'] }}"></time>, by {{ transplant['requester_email'] }}.</p>
-            <p><strong>Revisions:</strong>
-            {% for i in transplant['landing_path'] %}{{
-            "" if loop.first else " ← "
-            }}<a href="{{ i['revision_id']|revision_url(diff_id=i['diff_id']) }}">
-                {{ i['revision_id'] }} diff {{ i['diff_id'] }}
-            </a>{% endfor %}
-            </p>
-            {% if transplant.error_breakdown %}
-            {% set reject_paths = transplant.error_breakdown.reject_paths %}
-            <p>While applying <a href="{{ transplant.error_breakdown.revision_id|revision_url() }}">revision D{{ transplant.error_breakdown.revision_id }}</a> to {{ transplant.tree }}, the following files had conflicts:</p>
-            <p>(Hint: try rebasing your changes on the latest commits from {{ transplant.tree }} and re-submitting.)</p>
-            <div class="content">
-                <ul>
-                    {% for path in transplant.error_breakdown.failed_paths if path.path in reject_paths %}
-                        <li><strong>{{ path.path }}</strong> @ <a href="{{ path.url }}">{{ path.changeset_id }}</a></li>
-                        {% set reject_lines = reject_paths[path.path].content.split("\n") %}
-                        {% if reject_lines.__len__() < 3 %}
-                            <pre>{{ "\n".join(reject_lines) }}</pre>
-                        {% else %}
-                            <div>
-                                <pre class="snippet">{{ "\n".join(reject_lines[:2]) + "\n...\n" }}<button class="is-small is-light button toggle-content">expand diff</button></pre>
-                                <pre class="hidden-content">{{ "\n".join(reject_lines) }}<button class="is-small is-light button toggle-content">collapse diff</button></pre>
-                            </div>
-                        {% endif %}
-                    {% endfor %}
-                </ul?>
+    <div class="StackPage-timeline-itemDetail">
+      <p>Landing requested on <time data-timestamp="{{ transplant['created_at'] }}"></time>, by {{
+        transplant['requester_email'] }}.</p>
+      <p><strong>Revisions:</strong>
+        {% for i in transplant['landing_path'] %}{{
+        "" if loop.first else " ← "
+        }}<a href="{{ i['revision_id']|revision_url(diff_id=i['diff_id']) }}">
+          {{ i['revision_id'] }} diff {{ i['diff_id'] }}
+        </a>{% endfor %}
+      </p>
+      {% if transplant.error_breakdown %}
+      {% set reject_paths = transplant.error_breakdown.reject_paths %}
+      <p>While applying <a href="{{ transplant.error_breakdown.revision_id|revision_url() }}">revision D{{
+          transplant.error_breakdown.revision_id }}</a> to {{ transplant.tree }}, the following files had conflicts:</p>
+      <p>(Hint: try rebasing your changes on the latest commits from {{ transplant.tree }} and re-submitting.)</p>
+      <div class="content">
+        <ul>
+          {% for path in transplant.error_breakdown.failed_paths if path.path in reject_paths %}
+          <li><strong>{{ path.path }}</strong> @ <a href="{{ path.url }}">{{ path.changeset_id }}</a></li>
+          {% set reject_lines = reject_paths[path.path].content.split("\n") %}
+          {% if reject_lines.__len__() < 3 %} <pre>{{ "\n".join(reject_lines) }}</pre>
+            {% else %}
+            <div>
+              <pre class="snippet">{{ "\n".join(reject_lines[:2]) + "\n...\n" }}<button
+                  class="is-small is-light button toggle-content">expand diff</button></pre>
+              <pre class="hidden-content">{{ "\n".join(reject_lines) }}<button
+                  class="is-small is-light button toggle-content">collapse diff</button></pre>
             </div>
             {% endif %}
-            <div>
-                {% if transplant['status'].lower() == 'landed' %}
-                <strong>Result:</strong> {{ transplant['details']|escape_html|linkify_transplant_details(transplant)|safe }}
-                {% elif transplant['details'] %}
-                    <div class="StackPage-timeline-item-error">
-                    {% if transplant.error_breakdown %}
-                        <div><button type="button" class="is-light button toggle-content">Show raw error output</button></div>
-                        <pre class="hidden-content"><strong>Raw error output:</strong>{{ "\n" +  transplant['details'] }}</pre>
-                    {% else %}
-                        <pre><strong>Raw error output:</strong>{{ "\n" +  transplant['details'] }}</pre>
-                    {% endif %}
-                    </div>
-                {% endif %}
-                {% if transplant['status'] in ("SUBMITTED", "DEFERRED") %}
-                <button data-landing_job_id="{{ transplant['id'] }}" class="cancel-landing-job button is-small is-danger" data-csrf-token="{{ csrf_token }}">Cancel landing request</button>
-                {% endif %}
-            </div>
+            {% endfor %}
+            </ul?>
+      </div>
+      {% endif %}
+      <div>
+        {% if transplant['status'].lower() == 'landed' %}
+        <strong>Result:</strong> {{ transplant['details']|escape_html|linkify_transplant_details(transplant)|safe }}
+        {% elif transplant['details'] %}
+        <div class="StackPage-timeline-item-error">
+          {% if transplant.error_breakdown %}
+          <div><button type="button" class="is-light button toggle-content">Show raw error output</button></div>
+          <pre class="hidden-content"><strong>Raw error output:</strong>{{ "\n" + transplant['details'] }}</pre>
+          {% else %}
+          <pre><strong>Raw error output:</strong>{{ "\n" + transplant['details'] }}</pre>
+          {% endif %}
         </div>
+        {% endif %}
+        {% if transplant['status'] in ("SUBMITTED", "DEFERRED") %}
+        <button data-landing_job_id="{{ transplant['id'] }}" class="cancel-landing-job button is-small is-danger">Cancel
+          landing request</button>
+        {% endif %}
+      </div>
     </div>
-    {% endfor %}
-    {% else %}
-    <div class="StackPage-timeline-item">
-        <div class="StackPage-timeline-itemStatus">
-            <span class="Badge">Not yet Landed</span>
-        </div>
-        <div class="StackPage-timeline-itemDetail">
-            There has been no attempt to land revisions in this stack.
-        </div>
+  </div>
+  {% endfor %}
+  {% else %}
+  <div class="StackPage-timeline-item">
+    <div class="StackPage-timeline-itemStatus">
+      <span class="Badge">Not yet Landed</span>
     </div>
-    {% endif %}
+    <div class="StackPage-timeline-itemDetail">
+      There has been no attempt to land revisions in this stack.
+    </div>
+  </div>
+  {% endif %}
 </div>

--- a/src/lando/ui/jinja2/stack/partials/timeline.html
+++ b/src/lando/ui/jinja2/stack/partials/timeline.html
@@ -1,73 +1,69 @@
 <div class="StackPage-timeline">
-  {% if transplants %}
-  {%- for transplant in transplants|sort(attribute='updated_at', reverse=True) %}
-  <div class="StackPage-timeline-item">
-    <div class="StackPage-timeline-itemStatus">
-      <span class="{{ transplant|tostatusbadgeclass }}">{{transplant|tostatusbadgename}}</span>
-    </div>
+    {% if transplants %}
+    {%- for transplant in transplants|sort(attribute='updated_at', reverse=True) %}
+    <div class="StackPage-timeline-item">
+        <div class="StackPage-timeline-itemStatus">
+            <span class="{{ transplant|tostatusbadgeclass }}">{{transplant|tostatusbadgename}}</span>
+        </div>
 
-    <div class="StackPage-timeline-itemDetail">
-      <p>Landing requested on <time data-timestamp="{{ transplant['created_at'] }}"></time>, by {{
-        transplant['requester_email'] }}.</p>
-      <p><strong>Revisions:</strong>
-        {% for i in transplant['landing_path'] %}{{
-        "" if loop.first else " ← "
-        }}<a href="{{ i['revision_id']|revision_url(diff_id=i['diff_id']) }}">
-          {{ i['revision_id'] }} diff {{ i['diff_id'] }}
-        </a>{% endfor %}
-      </p>
-      {% if transplant.error_breakdown %}
-      {% set rejects_paths = transplant.error_breakdown.rejects_paths %}
-      <p>While applying <a href="{{ transplant.error_breakdown.revision_id|revision_url() }}">revision D{{
-          transplant.error_breakdown.revision_id }}</a> to {{ transplant.tree }}, the following files had conflicts:</p>
-      <p>(Hint: try rebasing your changes on the latest commits from {{ transplant.tree }} and re-submitting.)</p>
-      <div class="content">
-        <ul>
-          {% for path in transplant.error_breakdown.failed_paths if path.path in rejects_paths %}
-          <li><strong>{{ path.path }}</strong> @ <a href="{{ path.url }}">{{ path.changeset_id }}</a></li>
-          {% set reject_lines = rejects_paths[path.path].content.split("\n") %}
-          {% if reject_lines.__len__() < 3 %} <pre>{{ "\n".join(reject_lines) }}</pre>
-            {% else %}
-            <div>
-              <pre class="snippet">{{ "\n".join(reject_lines[:2]) + "\n...\n" }}<button
-                  class="is-small is-light button toggle-content">expand diff</button></pre>
-              <pre class="hidden-content">{{ "\n".join(reject_lines) }}<button
-                  class="is-small is-light button toggle-content">collapse diff</button></pre>
+        <div class="StackPage-timeline-itemDetail">
+            <p>Landing requested on <time data-timestamp="{{ transplant['created_at'] }}"></time>, by {{ transplant['requester_email'] }}.</p>
+            <p><strong>Revisions:</strong>
+            {% for i in transplant['landing_path'] %}{{
+            "" if loop.first else " ← "
+            }}<a href="{{ i['revision_id']|revision_url(diff_id=i['diff_id']) }}">
+                {{ i['revision_id'] }} diff {{ i['diff_id'] }}
+            </a>{% endfor %}
+            </p>
+            {% if transplant.error_breakdown %}
+            {% set rejects_paths = transplant.error_breakdown.rejects_paths %}
+            <p>While applying <a href="{{ transplant.error_breakdown.revision_id|revision_url() }}">revision D{{ transplant.error_breakdown.revision_id }}</a> to {{ transplant.tree }}, the following files had conflicts:</p>
+            <p>(Hint: try rebasing your changes on the latest commits from {{ transplant.tree }} and re-submitting.)</p>
+            <div class="content">
+                <ul>
+                    {% for path in transplant.error_breakdown.failed_paths if path.path in rejects_paths %}
+                        <li><strong>{{ path.path }}</strong> @ <a href="{{ path.url }}">{{ path.changeset_id }}</a></li>
+                        {% set reject_lines = rejects_paths[path.path].content.split("\n") %}
+                        {% if reject_lines.__len__() < 3 %}
+                            <pre>{{ "\n".join(reject_lines) }}</pre>
+                        {% else %}
+                            <div>
+                                <pre class="snippet">{{ "\n".join(reject_lines[:2]) + "\n...\n" }}<button class="is-small is-light button toggle-content">expand diff</button></pre>
+                                <pre class="hidden-content">{{ "\n".join(reject_lines) }}<button class="is-small is-light button toggle-content">collapse diff</button></pre>
+                            </div>
+                        {% endif %}
+                    {% endfor %}
+                </ul?>
             </div>
             {% endif %}
-            {% endfor %}
-            </ul?>
-      </div>
-      {% endif %}
-      <div>
-        {% if transplant['status'].lower() == 'landed' %}
-        <strong>Result:</strong> {{ transplant['details']|escape_html|linkify_transplant_details(transplant)|safe }}
-        {% elif transplant['details'] %}
-        <div class="StackPage-timeline-item-error">
-          {% if transplant.error_breakdown %}
-          <div><button type="button" class="is-light button toggle-content">Show raw error output</button></div>
-          <pre class="hidden-content"><strong>Raw error output:</strong>{{ "\n" + transplant['details'] }}</pre>
-          {% else %}
-          <pre><strong>Raw error output:</strong>{{ "\n" + transplant['details'] }}</pre>
-          {% endif %}
+            <div>
+                {% if transplant['status'].lower() == 'landed' %}
+                <strong>Result:</strong> {{ transplant['details']|escape_html|linkify_transplant_details(transplant)|safe }}
+                {% elif transplant['details'] %}
+                    <div class="StackPage-timeline-item-error">
+                    {% if transplant.error_breakdown %}
+                        <div><button type="button" class="is-light button toggle-content">Show raw error output</button></div>
+                        <pre class="hidden-content"><strong>Raw error output:</strong>{{ "\n" +  transplant['details'] }}</pre>
+                    {% else %}
+                        <pre><strong>Raw error output:</strong>{{ "\n" +  transplant['details'] }}</pre>
+                    {% endif %}
+                    </div>
+                {% endif %}
+                {% if transplant['status'] in ("SUBMITTED", "DEFERRED") %}
+                <button data-landing_job_id="{{ transplant['id'] }}" class="cancel-landing-job button is-small is-danger" data-csrf-token="{{ csrf_token }}">Cancel landing request</button>
+                {% endif %}
+            </div>
         </div>
-        {% endif %}
-        {% if transplant['status'] in ("SUBMITTED", "DEFERRED") %}
-        <button data-landing_job_id="{{ transplant['id'] }}" class="cancel-landing-job button is-small is-danger">Cancel
-          landing request</button>
-        {% endif %}
-      </div>
     </div>
-  </div>
-  {% endfor %}
-  {% else %}
-  <div class="StackPage-timeline-item">
-    <div class="StackPage-timeline-itemStatus">
-      <span class="Badge">Not yet Landed</span>
+    {% endfor %}
+    {% else %}
+    <div class="StackPage-timeline-item">
+        <div class="StackPage-timeline-itemStatus">
+            <span class="Badge">Not yet Landed</span>
+        </div>
+        <div class="StackPage-timeline-itemDetail">
+            There has been no attempt to land revisions in this stack.
+        </div>
     </div>
-    <div class="StackPage-timeline-itemDetail">
-      There has been no attempt to land revisions in this stack.
-    </div>
-  </div>
-  {% endif %}
+    {% endif %}
 </div>

--- a/src/lando/ui/jinja2/stack/partials/timeline.html
+++ b/src/lando/ui/jinja2/stack/partials/timeline.html
@@ -17,15 +17,15 @@
         </a>{% endfor %}
       </p>
       {% if transplant.error_breakdown %}
-      {% set reject_paths = transplant.error_breakdown.reject_paths %}
+      {% set rejects_paths = transplant.error_breakdown.rejects_paths %}
       <p>While applying <a href="{{ transplant.error_breakdown.revision_id|revision_url() }}">revision D{{
           transplant.error_breakdown.revision_id }}</a> to {{ transplant.tree }}, the following files had conflicts:</p>
       <p>(Hint: try rebasing your changes on the latest commits from {{ transplant.tree }} and re-submitting.)</p>
       <div class="content">
         <ul>
-          {% for path in transplant.error_breakdown.failed_paths if path.path in reject_paths %}
+          {% for path in transplant.error_breakdown.failed_paths if path.path in rejects_paths %}
           <li><strong>{{ path.path }}</strong> @ <a href="{{ path.url }}">{{ path.changeset_id }}</a></li>
-          {% set reject_lines = reject_paths[path.path].content.split("\n") %}
+          {% set reject_lines = rejects_paths[path.path].content.split("\n") %}
           {% if reject_lines.__len__() < 3 %} <pre>{{ "\n".join(reject_lines) }}</pre>
             {% else %}
             <div>


### PR DESCRIPTION
Add test coverage for good measure (and remove the never-used `job.error_breakdown["content"]`).

Much better!

Before:
![2024-12-19T16:54:18,990160289+11:00](https://github.com/user-attachments/assets/c3c4386f-30d6-4838-8860-c6e343ca7b6f)
After:
![2024-12-19T16:55:32,929871564+11:00](https://github.com/user-attachments/assets/2696e475-7feb-4d4b-af92-8c09868d29e5)
