### PR TITLE
git: add `.coverage` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ env
 staticfiles
 src/lando/version.py
 .test-use-suite
+.coverage


### PR DESCRIPTION
We generate this file as part of code coverage reports in
the test suite, it should be ignored by Git.
