### PR TITLE
tests: handle skipped tests (bug 1897504)

### DIFF
--- a/src/lando/api/legacy/api/landing_jobs.py
+++ b/src/lando/api/legacy/api/landing_jobs.py
@@ -2,7 +2,7 @@ import json
 import logging
 
 from django import forms
-from django.http import Http404, HttpRequest, JsonResponse
+from django.http import HttpRequest, JsonResponse
 
 from lando.main.auth import require_authenticated_user
 from lando.main.models.landing_job import LandingJob, LandingJobAction, LandingJobStatus
@@ -59,12 +59,16 @@ def put(request: HttpRequest, landing_job_id: int) -> JsonResponse:
         try:
             landing_job = LandingJob.objects.get(pk=landing_job_id)
         except LandingJob.DoesNotExist:
-            raise Http404(f"A landing job with ID {landing_job_id} was not found.")
+            return JsonResponse(
+                {"detail": f"A landing job with ID {landing_job_id} was not found."},
+                status=404,
+            )
 
     ldap_username = request.user.email
     if landing_job.requester_email != ldap_username:
-        raise PermissionError(
-            f"User not authorized to update landing job {landing_job_id}"
+        return JsonResponse(
+            {"detail": f"User not authorized to update landing job {landing_job_id}"},
+            status=403,
         )
 
     if status != "CANCELLED":

--- a/src/lando/api/tests/test_hooks.py
+++ b/src/lando/api/tests/test_hooks.py
@@ -4,10 +4,6 @@ from lando.api.legacy.treestatus import (
     TreeStatusCommunicationException,
     TreeStatusError,
 )
-from lando.utils.phabricator import (
-    PhabricatorAPIException,
-    PhabricatorCommunicationException,
-)
 
 
 @pytest.mark.django_db
@@ -42,29 +38,6 @@ def test_app_wide_headers_csp_report_uri(app, client):
     response = client.get("/__version__")
     assert response.status_code == 200
     assert "report-uri /__cspreport__" in (response.headers["Content-Security-Policy"])
-
-
-@pytest.mark.skip
-def test_phabricator_api_exception_handled(db, app, client):
-    # We need to tell Flask to handle exceptions as if it were in a production
-    # environment.
-    app.config["PROPAGATE_EXCEPTIONS"] = False
-
-    @app.route("/__testing__/phab_exception1")
-    def phab_exception1():
-        raise PhabricatorAPIException("OOPS!")
-
-    @app.route("/__testing__/phab_exception2")
-    def phab_exception2():
-        raise PhabricatorCommunicationException("OOPS!")
-
-    response = client.get("__testing__/phab_exception1")
-    assert response.status_code == 500
-    assert response.json["title"] == "Phabricator Error"
-
-    response = client.get("__testing__/phab_exception2")
-    assert response.status_code == 500
-    assert response.json["title"] == "Phabricator Error"
 
 
 @pytest.mark.skip

--- a/src/lando/static_src/legacy/js/components/Timeline.js
+++ b/src/lando/static_src/legacy/js/components/Timeline.js
@@ -12,7 +12,7 @@ $.fn.timeline = function() {
       var landing_job_id = this.dataset.landing_job_id;
 
       button.addClass("is-loading");
-      fetch(`/landing_jobs/${landing_job_id}`, {
+      fetch(`/landing_jobs/${landing_job_id}/`, {
         method: 'PUT',
         body: JSON.stringify({"status": "CANCELLED"}),
         headers: {


### PR DESCRIPTION
- fix landing job cancel tests
- remove unneeded phabricator exception test
- fix bug in JS code that called endpoint without trailing slash