### PR TITLE
create_environment_repos: fix error log

### DIFF
--- a/src/lando/utils/management/commands/create_environment_repos.py
+++ b/src/lando/utils/management/commands/create_environment_repos.py
@@ -303,7 +303,7 @@ class Command(BaseCommand):
             try:
                 repo = Repo.objects.create(**definition)
             except IntegrityError as e:
-                self.stderr.write(e)
+                self.stderr.write(str(e))
                 self.stdout.write(
                     self.style.WARNING(
                         f"Repo {definition['name']} already exists or could not be added, skipping."


### PR DESCRIPTION
This was causing `AttributeError: 'IntegrityError' object has no attribute 'endswith'`.