### PR TITLE
landing_worker: mark log message as an f-string

### DIFF
--- a/src/lando/api/legacy/workers/landing_worker.py
+++ b/src/lando/api/legacy/workers/landing_worker.py
@@ -75,7 +75,7 @@ class LandingWorker(Worker):
     def loop(self):
         logger.debug(
             f"{len(self.worker_instance.enabled_repos)} "
-            "enabled repos: {self.worker_instance.enabled_repos}"
+            f"enabled repos: {self.worker_instance.enabled_repos}"
         )
 
         # Refresh repos if there is a mismatch in active vs. enabled repos.


### PR DESCRIPTION
The "enabled repos" line in the debug logging statement is missing
the `f` prefix to mark it as an f-string.