### PR TITLE
landing_worker: port autoformatting changes from bug 1924891 (Bug 1954781)

### DIFF
--- a/src/lando/api/legacy/workers/landing_worker.py
+++ b/src/lando/api/legacy/workers/landing_worker.py
@@ -439,7 +439,17 @@ class LandingWorker(Worker):
         Changes made by code formatters are applied to the working directory and
         are not committed into version control.
         """
-        return self.run_mach_command(path, ["lint", "--fix", "--outgoing"])
+        supported_formatters = [
+            "black",
+            "clang-format",
+            "rustfmt",
+        ]
+
+        linter_args = [f"--linter={formatter}" for formatter in supported_formatters]
+
+        return self.run_mach_command(
+            path, ["lint", *linter_args, "--fix", "--outgoing", "--verbose"]
+        )
 
     def run_mach_bootstrap(self, path: str) -> str:
         """Run `mach bootstrap` to configure the system for code formatting."""


### PR DESCRIPTION
During the LandoAPI repo merge, the autoformatting changes from
bug 1924891 were not correctly merged into the new repo. Port
the changes so only the verified subset of linters run in
new Lando.
