### PR TITLE
landing_worker: use `mach format` for autoformatting (Bug 1807712)

### DIFF
--- a/src/lando/api/legacy/workers/landing_worker.py
+++ b/src/lando/api/legacy/workers/landing_worker.py
@@ -439,16 +439,8 @@ class LandingWorker(Worker):
         Changes made by code formatters are applied to the working directory and
         are not committed into version control.
         """
-        supported_formatters = [
-            "black",
-            "clang-format",
-            "rustfmt",
-        ]
-
-        linter_args = [f"--linter={formatter}" for formatter in supported_formatters]
-
         return self.run_mach_command(
-            path, ["lint", *linter_args, "--fix", "--outgoing", "--verbose"]
+            path, ["format", "--fix", "--outgoing", "--verbose"]
         )
 
     def run_mach_bootstrap(self, path: str) -> str:


### PR DESCRIPTION
Now that `mach format` runs `eslint` as a formatter without fixes,
we can use `mach format` to autoformat patches, removing the need
to maintain our own list of valid formatters.
