### PR TITLE
pages: fix misaligned warning checkboxes

### DIFF
--- a/src/lando/static_src/legacy/css/pages/StackPage.scss
+++ b/src/lando/static_src/legacy/css/pages/StackPage.scss
@@ -138,7 +138,7 @@ ul.StackPage-blockers {
     border-color: #A53030;
     color:#A53030;
     margin-bottom: 4px;
-    padding: 3px 9px 3px 30px;
+    padding: 3px 9px;
     position: relative;
   }
 }
@@ -268,14 +268,8 @@ ul.StackPage-blockers {
     border-color: #e9dbcd;
     color:#726f56;
     margin-bottom: 4px;
-    padding: 3px 9px 3px 30px;
+    padding: 3px 9px;
     position: relative;
-
-    input {
-      position: absolute;
-      top: 10px;
-      left: 8px;
-    }
   }
 
   &-blocker {
@@ -283,7 +277,7 @@ ul.StackPage-blockers {
     border-color: #A53030;
     color:#A53030;
     margin-bottom: 4px;
-    padding: 3px 9px 3px 30px;
+    padding: 3px 9px;
     position: relative;
   }
 


### PR DESCRIPTION
This lets the browser position the checkbox to the baseline rather than manually positioning it.