### PR TITLE
tests: set UTC timezone in `datetime.now` calls (Bug 1958317)

### DIFF
--- a/src/lando/main/tests/test_models.py
+++ b/src/lando/main/tests/test_models.py
@@ -138,7 +138,7 @@ def test__models__Revision__metadata():
 
     More lines
     """
-    timestamp = datetime.now(timezone.utc).strftime("%s")
+    timestamp = datetime.now(tz=timezone.utc).strftime("%s")
 
     r = Revision.new_from_patch(
         raw_diff=DIFF_ONLY,

--- a/src/lando/main/tests/test_models.py
+++ b/src/lando/main/tests/test_models.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -138,7 +138,7 @@ def test__models__Revision__metadata():
 
     More lines
     """
-    timestamp = datetime.now().strftime("%s")
+    timestamp = datetime.now(timezone.utc).strftime("%s")
 
     r = Revision.new_from_patch(
         raw_diff=DIFF_ONLY,

--- a/src/lando/pushlog/tests/conftest.py
+++ b/src/lando/pushlog/tests/conftest.py
@@ -97,7 +97,7 @@ def make_scm_commit(make_hash):
             desc=f"""SCM Commit {seqno}
 
 Another line""",
-            datetime=datetime.now(timezone.utc),
+            datetime=datetime.now(tz=timezone.utc),
             # The first commit doesn't have a parent.
             parents=[make_hash(seqno - 1)] if seqno > 1 else [],
             files=[f"/file-{s}" for s in range(seqno)],

--- a/src/lando/pushlog/tests/conftest.py
+++ b/src/lando/pushlog/tests/conftest.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 
 import pytest
 
@@ -43,7 +43,7 @@ def make_commit(make_hash):
             repo=repo,
             author=f"author-{seqno}",
             desc=message,
-            datetime=datetime.now(),
+            datetime=datetime.now(tz=timezone.utc),
         )
 
     return commit_factory
@@ -97,7 +97,7 @@ def make_scm_commit(make_hash):
             desc=f"""SCM Commit {seqno}
 
 Another line""",
-            datetime=datetime.now(),
+            datetime=datetime.now(timezone.utc),
             # The first commit doesn't have a parent.
             parents=[make_hash(seqno - 1)] if seqno > 1 else [],
             files=[f"/file-{s}" for s in range(seqno)],


### PR DESCRIPTION
Set UTC timezone when calling `datetime.now`. This silences warnings
about using a naive timestamp when the ORM uses timestamped datetimes.
