### PR TITLE
automation-actions: implement `create-commit` action (Bug 1959441)

### DIFF
--- a/src/lando/headless_api/api.py
+++ b/src/lando/headless_api/api.py
@@ -178,6 +178,48 @@ class AddCommitAction(Schema):
         return True
 
 
+class CreateCommitAction(Schema):
+    """Create a new commit from a diff and metadata."""
+
+    action: Literal["create-commit"]
+    author: str
+    commit_message: str
+    date: datetime.datetime
+    diff: str
+
+    def process(
+        self, job: AutomationJob, repo: Repo, scm: AbstractSCM, index: int
+    ) -> bool:
+        """Create a new commit from a diff and metadata."""
+        try:
+            scm.apply_patch(
+                self.diff,
+                self.commit_message,
+                self.author,
+                self.date.isoformat(),
+            )
+        except PatchConflict as exc:
+            message = (
+                f"Merge conflict while creating commit in `create-commit`, "
+                f"action #{index}.\n\n"
+                f"{str(exc)}"
+            )
+            raise AutomationActionException(
+                message=message, job_action=JobAction.FAIL, is_fatal=False
+            )
+        except Exception as e:
+            message = (
+                f"Aborting, could not create commit from `create-commit`, "
+                f"action #{index}."
+                f"\n{e}"
+            )
+            raise AutomationActionException(
+                message=message, job_action=JobAction.FAIL, is_fatal=False
+            )
+
+        return True
+
+
 class MergeOntoAction(Schema):
     """Merge the current branch into the target commit."""
 
@@ -219,7 +261,9 @@ class AddBranchAction(Schema):
         raise NotImplementedError()
 
 
-Action = Union[AddCommitAction, MergeOntoAction, AddBranchAction, TagAction]
+Action = Union[
+    AddCommitAction, CreateCommitAction, MergeOntoAction, AddBranchAction, TagAction
+]
 
 ActionAdapter = TypeAdapter(Action)
 

--- a/src/lando/headless_api/tests/test_automation_api.py
+++ b/src/lando/headless_api/tests/test_automation_api.py
@@ -589,6 +589,109 @@ def test_automation_job_add_commit_fail(
     assert scm.push.call_count == 0
 
 
+PATCH_DIFF = """
+diff --git a/test.txt b/test.txt
+--- a/test.txt
++++ b/test.txt
+@@ -1,1 +1,2 @@
+ TEST
++adding another line
+""".lstrip()
+
+
+@pytest.mark.django_db
+def test_automation_job_create_commit_success_hg(
+    hg_server, hg_clone, repo_mc, treestatusdouble, hg_automation_worker, monkeypatch
+):
+    repo = repo_mc(SCM_TYPE_HG)
+    scm = repo.scm
+
+    # Create a job and actions
+    job = AutomationJob.objects.create(
+        status=JobStatus.SUBMITTED,
+        requester_email="example@example.com",
+        target_repo=repo,
+    )
+    AutomationAction.objects.create(
+        job_id=job,
+        action_type="create-commit",
+        data={
+            "action": "create-commit",
+            "author": "Test User <test@example.com>",
+            "commit_message": "add another file",
+            "date": 0,
+            "diff": PATCH_DIFF,
+        },
+        order=0,
+    )
+
+    hg_automation_worker.worker_instance.applicable_repos.add(repo)
+
+    # Mock `phab_trigger_repo_update` so we can make sure that it was called.
+    mock_trigger_update = mock.MagicMock()
+    monkeypatch.setattr(
+        "lando.api.legacy.workers.automation_worker.AutomationWorker.phab_trigger_repo_update",
+        mock_trigger_update,
+    )
+
+    scm.push = mock.MagicMock()
+
+    assert hg_automation_worker.run_automation_job(job)
+    assert scm.push.call_count == 1
+    assert len(scm.push.call_args) == 2
+    assert len(scm.push.call_args[0]) == 1
+    assert scm.push.call_args[0][0] == hg_server
+    assert scm.push.call_args[1] == {"push_target": "", "force_push": False}
+    assert job.status == JobStatus.LANDED, job.error
+    assert len(job.landed_commit_id) == 40, "Landed commit ID should be a 40-char SHA."
+
+
+@pytest.mark.django_db
+def test_automation_job_create_commit_success_git(
+    treestatusdouble, git_automation_worker, repo_mc, monkeypatch, normal_patch
+):
+    repo = repo_mc(SCM_TYPE_GIT)
+    scm = repo.scm
+
+    # Create a job and actions
+    job = AutomationJob.objects.create(
+        status=JobStatus.SUBMITTED,
+        requester_email="example@example.com",
+        target_repo=repo,
+    )
+    AutomationAction.objects.create(
+        job_id=job,
+        action_type="create-commit",
+        data={
+            "action": "create-commit",
+            "author": "Test User <test@example.com>",
+            "commit_message": "add another file",
+            "date": 0,
+            "diff": PATCH_DIFF,
+        },
+        order=0,
+    )
+
+    git_automation_worker.worker_instance.applicable_repos.add(repo)
+
+    # Mock `phab_trigger_repo_update` so we can make sure that it was called.
+    mock_trigger_update = mock.MagicMock()
+    monkeypatch.setattr(
+        "lando.api.legacy.workers.automation_worker.AutomationWorker.phab_trigger_repo_update",
+        mock_trigger_update,
+    )
+
+    scm.push = mock.MagicMock()
+
+    assert git_automation_worker.run_automation_job(job)
+    assert scm.push.call_count == 1
+    assert len(scm.push.call_args) == 2
+    assert len(scm.push.call_args[0]) == 1
+    assert scm.push.call_args[1] == {"push_target": "", "force_push": False}
+    assert job.status == JobStatus.LANDED, job.error
+    assert len(job.landed_commit_id) == 40, "Landed commit ID should be a 40-char SHA."
+
+
 @pytest.mark.django_db
 def test_token_generation_security(headless_user):
     user, token = headless_user


### PR DESCRIPTION
Implement the `create-commit` action, which is similar to the
existing `add-commit` action, except the commit data is passed
as a diff and metadata fields directly.
