### PR TITLE
automation-actions: implement `merge-onto` action (Bug 1959823)

### DIFF
--- a/src/lando/api/tests/test_hg.py
+++ b/src/lando/api/tests/test_hg.py
@@ -417,3 +417,103 @@ def _create_hg_commit(request: pytest.FixtureRequest, clone_path: Path):
     )
 
     return new_file
+
+
+@pytest.mark.parametrize("strategy", [None, "ours", "theirs"])
+def test_HgSCM_merge_onto(
+    hg_clone,
+    request: pytest.FixtureRequest,
+    strategy: str | None,
+):
+    scm = HgSCM(hg_clone.strpath)
+
+    with scm.for_push(f"pytest+{request.node.name}@lando"):
+        # Start on the default branch (main)
+        main_start_commit = scm.head_ref()
+
+        # Create commits on main branch
+        main_file = _create_hg_commit(request, Path(hg_clone))
+        _create_hg_commit(request, Path(hg_clone))
+        _create_hg_commit(request, Path(hg_clone))
+        main_commit = scm.head_ref()
+
+        # Update to start commit and create separate feature history
+        subprocess.run(
+            ["hg", "update", "--clean", "-r", main_start_commit],
+            cwd=str(hg_clone),
+            check=True,
+        )
+
+        feature_file = _create_hg_commit(request, Path(hg_clone))
+        _create_hg_commit(request, Path(hg_clone))
+        _create_hg_commit(request, Path(hg_clone))
+        feature_commit = scm.head_ref()
+
+        # Update back to main and merge in feature
+        subprocess.run(
+            ["hg", "update", "--clean", "-r", main_commit],
+            cwd=str(hg_clone),
+            check=True,
+        )
+
+        merge_msg = f"Merge main into feature with strategy {strategy}"
+        merge_node = scm.merge_onto(merge_msg, feature_commit, strategy)
+
+        # Check that the merge commit has two parents
+        parents = (
+            subprocess.run(
+                ["hg", "log", "-r", merge_node, "-T", "{p1node} {p2node}"],
+                cwd=str(hg_clone),
+                capture_output=True,
+                check=True,
+            )
+            .stdout.decode()
+            .strip()
+            .split()
+        )
+
+        assert (
+            len(parents) == 2
+        ), f"Expected merge commit with 2 parents, got: {parents}"
+        assert (
+            main_commit in parents and feature_commit in parents
+        ), f"Unexpected merge parents: {parents}"
+
+        # Pick the file and commit that should define the content
+        if strategy == "ours":
+            file_to_check = main_file
+            expected_rev = main_commit
+        elif strategy == "theirs":
+            file_to_check = feature_file
+            expected_rev = feature_commit
+        else:
+            # We don't know which content will win in normal merge,
+            # so we just ensure the file exists
+            file_to_check = feature_file
+            expected_rev = None
+
+        # Check the content in the merge commit
+        merged_content = subprocess.run(
+            ["hg", "cat", "-r", merge_node, file_to_check.name],
+            cwd=str(hg_clone),
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+
+        if expected_rev:
+            expected_content = subprocess.run(
+                ["hg", "cat", "-r", expected_rev, file_to_check.name],
+                cwd=str(hg_clone),
+                capture_output=True,
+                text=True,
+                check=True,
+            ).stdout.strip()
+
+            assert all(
+                {merged_content, expected_content}
+            ), "File contents should be non-empty"
+
+            assert (
+                merged_content == expected_content
+            ), f"File contents did not match expected for strategy {strategy}"

--- a/src/lando/headless_api/tests/test_automation_api.py
+++ b/src/lando/headless_api/tests/test_automation_api.py
@@ -1,12 +1,15 @@
 import datetime
 import json
 import secrets
+import subprocess
 import unittest.mock as mock
+from pathlib import Path
 
 import pytest
 from django.contrib.auth.hashers import check_password
 
 from lando.api.legacy.workers.automation_worker import AutomationWorker
+from lando.api.tests.test_hg import _create_hg_commit
 from lando.headless_api.api import (
     AutomationAction,
     AutomationJob,
@@ -16,6 +19,7 @@ from lando.main.models import SCM_LEVEL_3, Repo
 from lando.main.models.landing_job import JobStatus
 from lando.main.scm import SCM_TYPE_GIT, SCM_TYPE_HG
 from lando.main.scm.exceptions import PatchConflict
+from lando.main.tests.test_git import _create_git_commit
 
 
 @pytest.mark.django_db
@@ -708,6 +712,189 @@ def test_automation_job_create_commit_patch_conflict(
     assert "Merge conflict while creating commit" in job.error
     job.refresh_from_db()
     assert job.status == JobStatus.FAILED
+
+
+def _create_split_branches_for_merge(
+    request, scm, repo_path, main_branch="main", feature_branch="feature"
+):
+    subprocess.run(["git", "switch", main_branch], cwd=repo_path, check=True)
+    main_file = _create_git_commit(request, repo_path)
+    main_commit = (
+        subprocess.run(
+            ["git", "rev-parse", "HEAD"], cwd=repo_path, capture_output=True, check=True
+        )
+        .stdout.decode()
+        .strip()
+    )
+
+    subprocess.run(
+        ["git", "switch", "-c", feature_branch, "HEAD^"], cwd=repo_path, check=True
+    )
+    feature_file = _create_git_commit(request, repo_path)
+    feature_commit = (
+        subprocess.run(
+            ["git", "rev-parse", "HEAD"], cwd=repo_path, capture_output=True, check=True
+        )
+        .stdout.decode()
+        .strip()
+    )
+
+    subprocess.run(["git", "switch", main_branch], cwd=repo_path, check=True)
+
+    return main_commit, main_file, feature_commit, feature_file
+
+
+@pytest.mark.parametrize("strategy", [None, "ours", "theirs"])
+@pytest.mark.django_db
+def test_automation_job_merge_onto_success_git(
+    strategy,
+    repo_mc,
+    treestatusdouble,
+    git_automation_worker,
+    monkeypatch,
+    request,
+):
+    repo = repo_mc(SCM_TYPE_GIT)
+    scm = repo.scm
+    scm.push = mock.MagicMock()
+
+    # Create a repo with diverging history
+    main_commit, main_file, feature_commit, feature_file = (
+        _create_split_branches_for_merge(request, scm, repo.system_path)
+    )
+
+    job = AutomationJob.objects.create(
+        status=JobStatus.SUBMITTED,
+        requester_email="test@example.com",
+        target_repo=repo,
+    )
+    AutomationAction.objects.create(
+        job_id=job,
+        action_type="merge-onto",
+        data={
+            "action": "merge-onto",
+            "commit_message": f"Merge test with strategy {strategy}",
+            "strategy": strategy,
+            "target": feature_commit,
+        },
+        order=0,
+    )
+
+    git_automation_worker.worker_instance.applicable_repos.add(repo)
+
+    assert git_automation_worker.run_automation_job(job)
+    assert job.status == JobStatus.LANDED
+    assert scm.push.called
+    assert len(job.landed_commit_id) == 40
+
+
+@pytest.mark.parametrize("strategy", [None, "ours", "theirs"])
+@pytest.mark.django_db
+def test_automation_job_merge_onto_success_hg(
+    strategy,
+    repo_mc,
+    treestatusdouble,
+    hg_automation_worker,
+    monkeypatch,
+    request,
+):
+    repo = repo_mc(SCM_TYPE_HG)
+    scm = repo.scm
+    scm.push = mock.MagicMock()
+
+    repo_path = Path(repo.system_path)
+
+    # Create commits on a feature branch
+    _create_hg_commit(request, repo_path)
+    _create_hg_commit(request, repo_path)
+    _create_hg_commit(request, repo_path)
+    feature_commit = subprocess.run(
+        ["hg", "log", "-r", ".", "-T", "{node}"],
+        cwd=repo_path,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+
+    # Return to rev 0 and create mainline commits
+    subprocess.run(["hg", "update", "--clean", "-r", "0"], cwd=repo_path, check=True)
+    _create_hg_commit(request, repo_path)
+    _create_hg_commit(request, repo_path)
+    _create_hg_commit(request, repo_path)
+    main_commit = subprocess.run(
+        ["hg", "log", "-r", ".", "-T", "{node}"],
+        cwd=repo_path,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+
+    # Push changes to hg_server before running the automation job
+    subprocess.run(
+        ["hg", "push", "-r", "draft()", repo.push_path, "-f"], cwd=repo_path, check=True
+    )
+
+    subprocess.run(
+        ["hg", "update", "--clean", "-r", main_commit], cwd=repo.system_path, check=True
+    )
+
+    job = AutomationJob.objects.create(
+        status=JobStatus.SUBMITTED,
+        requester_email="test@example.com",
+        target_repo=repo,
+    )
+    AutomationAction.objects.create(
+        job_id=job,
+        action_type="merge-onto",
+        data={
+            "action": "merge-onto",
+            "commit_message": f"merge test ({strategy})",
+            "strategy": strategy,
+            "target": feature_commit,
+        },
+        order=0,
+    )
+
+    hg_automation_worker.worker_instance.applicable_repos.add(repo)
+
+    assert hg_automation_worker.run_automation_job(job)
+    assert job.status == JobStatus.LANDED
+    assert scm.push.called
+    assert len(job.landed_commit_id) == 40
+
+
+@pytest.mark.parametrize("scm_type", (SCM_TYPE_HG, SCM_TYPE_GIT))
+@pytest.mark.django_db
+def test_automation_job_merge_onto_fail(
+    scm_type, repo_mc, treestatusdouble, get_automation_worker, monkeypatch
+):
+    repo = repo_mc(scm_type)
+
+    job = AutomationJob.objects.create(
+        status=JobStatus.SUBMITTED,
+        requester_email="test@example.com",
+        target_repo=repo,
+    )
+    AutomationAction.objects.create(
+        job_id=job,
+        action_type="merge-onto",
+        data={
+            "action": "merge-onto",
+            "commit_message": "bad merge",
+            "strategy": None,
+            "target": "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+        },
+        order=0,
+    )
+
+    automation_worker = get_automation_worker(scm_type)
+    automation_worker.worker_instance.applicable_repos.add(repo)
+
+    assert not automation_worker.run_automation_job(
+        job
+    ), f"Job should fail for SCM: {scm_type}"
+    assert job.status == JobStatus.FAILED
+    assert "Aborting, could not perform `merge-onto`" in job.error
 
 
 @pytest.mark.django_db

--- a/src/lando/main/scm/abstract_scm.py
+++ b/src/lando/main/scm/abstract_scm.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Any, ContextManager, Optional
 
 from lando.main.scm.commit import CommitData
+from lando.main.scm.consts import MergeStrategy
 
 logger = logging.getLogger(__name__)
 
@@ -216,3 +217,12 @@ class AbstractSCM:
 
         This is useful when parsing semi-structured multiline text output."""
         return "".join(random.choices(string.ascii_uppercase, k=16))
+
+    @abstractmethod
+    def merge_onto(
+        self, commit_message: str, target: str, strategy: Optional[MergeStrategy]
+    ) -> str:
+        """Create a merge commit on the specified repo.
+
+        Return the SHA of the newly created merge commit.
+        """

--- a/src/lando/main/scm/consts.py
+++ b/src/lando/main/scm/consts.py
@@ -1,2 +1,15 @@
+import enum
+
 SCM_TYPE_GIT = "git"
 SCM_TYPE_HG = "hg"
+
+
+@enum.unique
+class MergeStrategy(str, enum.Enum):
+    """Enumeration of acceptable non-default merge strategies.
+
+    This class is a subclass of `str` to enable serialization in Pydantic.
+    """
+
+    Ours = "ours"
+    Theirs = "theirs"

--- a/src/lando/main/scm/git.py
+++ b/src/lando/main/scm/git.py
@@ -14,7 +14,7 @@ from django.conf import settings
 from simple_github import AppAuth, AppInstallationAuth
 
 from lando.main.scm.commit import CommitData
-from lando.main.scm.consts import SCM_TYPE_GIT
+from lando.main.scm.consts import SCM_TYPE_GIT, MergeStrategy
 from lando.main.scm.exceptions import (
     PatchConflict,
     SCMException,
@@ -475,3 +475,58 @@ class GitSCM(AbstractSCM):
         env = os.environ.copy()
         env.update(cls.DEFAULT_ENV)
         return env
+
+    def merge_onto(
+        self, commit_message: str, target: str, strategy: Optional[MergeStrategy]
+    ) -> str:
+        """Create a merge commit on the specified repo.
+
+        Return the SHA of the newly created merge commit.
+        """
+
+        if strategy == MergeStrategy.Theirs:
+            current_branch = self._git_run(
+                "rev-parse", "--abbrev-ref", "HEAD", cwd=self.path
+            )
+            current_sha = self.head_ref()
+
+            # Switch to target and merge current into it with 'ours' strategy
+            self._git_run("checkout", target, cwd=self.path)
+
+            # Create merge commit that favors the target's content
+            self._git_run(
+                "merge",
+                "--no-ff",
+                # Use the `ours` strategy instead of `theirs`.
+                "-s",
+                "ours",
+                "-m",
+                commit_message,
+                current_sha,
+                cwd=self.path,
+            )
+
+            new_merge_commit = self.get_current_node()
+
+            # Move the original branch to point to the merge commit
+            self._git_run(
+                "branch", "-f", current_branch, new_merge_commit, cwd=self.path
+            )
+            self._git_run("switch", current_branch, cwd=self.path)
+
+            return new_merge_commit
+
+        # Set strategy args.
+        strategy_args = ["-s", strategy] if strategy else []
+
+        self._git_run(
+            "merge",
+            "--no-ff",
+            "-m",
+            commit_message,
+            *strategy_args,
+            target,
+            cwd=self.path,
+        )
+
+        return self.get_current_node()


### PR DESCRIPTION
Implement the `merge-onto` action for the automation API, which
takes a `target` and `strategy` parameter for the merge. If
the `strategy` isn't passed, a regular merge is performed and
merge conflicts are considered a failure. If the strategy is
"ours", the merge is performed with the current branches content
being taken. If the "theirs" strategy is passed, the target branches
content is preferred instead.
