### PR TITLE
automation-api: implement `repoinfo` endpoint (Bug 1961077)

### DIFF
--- a/src/lando/headless_api/tests/test_automation_api.py
+++ b/src/lando/headless_api/tests/test_automation_api.py
@@ -1015,4 +1015,6 @@ def test_get_repo_info_not_found(client, headless_user):
     )
 
     assert response.status_code == 404, "Non-existent repo should return 404."
-    assert response.json() == {"details": "Repo with short name nonexistent-repo does not exist."}
+    assert response.json() == {
+        "details": "Repo with short name nonexistent-repo does not exist."
+    }

--- a/src/lando/headless_api/tests/test_automation_api.py
+++ b/src/lando/headless_api/tests/test_automation_api.py
@@ -972,3 +972,47 @@ def test_token_prefix_collision(monkeypatch, headless_user):
     assert (
         ApiToken.verify_token(token2).user == user
     ), "Second token with common prefix should return headless user."
+
+
+@pytest.mark.django_db
+def test_get_repo_info_success(client, headless_user, repo_mc):
+    user, token = headless_user
+
+    repo = repo_mc(SCM_TYPE_GIT)
+
+    response = client.get(
+        f"/api/repoinfo/{repo.short_name}",
+        headers={
+            "User-Agent": "Lando-User/testuser@example.org",
+            "Authorization": f"Bearer {token}",
+        },
+    )
+
+    assert (
+        response.status_code == 200
+    ), "`repoinfo` should return 200 for successful response."
+
+    response_json = response.json()
+    assert response_json["repo_url"] == repo.url, "`repo_url` does not match expected."
+    assert (
+        response_json["branch_name"] == repo.default_branch
+    ), "`branch_name` does not match expected."
+    assert (
+        response_json["scm_level"] == "scm_level_3"
+    ), "`scm_level` does not match expected."
+
+
+@pytest.mark.django_db
+def test_get_repo_info_not_found(client, headless_user):
+    user, token = headless_user
+
+    response = client.get(
+        "/api/repoinfo/nonexistent-repo",
+        headers={
+            "User-Agent": "Lando-User/testuser@example.org",
+            "Authorization": f"Bearer {token}",
+        },
+    )
+
+    assert response.status_code == 404, "Non-existent repo should return 404."
+    assert response.json() == {"details": "Repo with short name nonexistent-repo does not exist."}


### PR DESCRIPTION
Add a simple endpoint to retrieve repo status given
a Phabricator short name.
