### PR TITLE
git: re-raise exceptions from Git in `apply_patch` (Bug 1961715)

### DIFF
--- a/src/lando/main/scm/git.py
+++ b/src/lando/main/scm/git.py
@@ -194,6 +194,8 @@ class GitSCM(AbstractSCM):
                     if "error: patch" in exc.err:
                         raise PatchConflict(exc.err) from exc
 
+                    raise exc
+
     def process_merge_conflict(
         self,
         pull_path: str,


### PR DESCRIPTION
Exceptions thrown by `_git_run` while applying patches are silently
swallowed while trying to convert them to `PatchConflict` exceptions.
Re-raise them here so any non-standard errors are seen.
