### PR TITLE
automation-actions: set a default for `target` so it is optional (Bug 1962171)

### DIFF
--- a/src/lando/headless_api/api.py
+++ b/src/lando/headless_api/api.py
@@ -255,7 +255,7 @@ class TagAction(Schema):
 
     action: Literal["tag"]
     name: str
-    target: str | None
+    target: str | None = None
 
     def process(
         self, job: AutomationJob, repo: Repo, scm: AbstractSCM, index: int


### PR DESCRIPTION
`target` is marked as `str | None`, however since there is no default
value set, it is required in the request body. Set `None` as the default
value to the field can be omitted.
