### PR TITLE
headless_api: store Pydantic models in DB using `.model_dump(mode="json")` (Bug 1962191)

### DIFF
--- a/src/lando/headless_api/api.py
+++ b/src/lando/headless_api/api.py
@@ -356,7 +356,7 @@ def post_repo_actions(
             AutomationAction.objects.create(
                 job_id=automation_job,
                 action_type=action.action,
-                data=action.dict(),
+                data=action.model_dump(mode="json"),
                 order=index,
             )
 

--- a/src/lando/headless_api/tests/test_automation_api.py
+++ b/src/lando/headless_api/tests/test_automation_api.py
@@ -377,7 +377,7 @@ def test_automation_job_create_commit_request(client, repo_mc, headless_user):
             {
                 "action": "create-commit",
                 "commitmsg": "test commit message",
-                "date": "2025-04-22T18:30:27.786900+00:00",
+                "date": "2025-04-22T18:30:27.786900Z",
                 "author": "Test User <test@example.com>",
                 "diff": "diff --git",
             }
@@ -396,6 +396,14 @@ def test_automation_job_create_commit_request(client, repo_mc, headless_user):
     assert (
         response.status_code == 202
     ), "Successful submission should result in `202 Accepted` status code."
+
+    job_id = response.json()["job_id"]
+    job = AutomationJob.objects.get(id=job_id)
+    action = job.actions.all()[0]
+
+    assert (
+        action.data["date"] == "2025-04-22T18:30:27.786900Z"
+    ), "`date` field should be serialized properly."
 
 
 @pytest.mark.django_db

--- a/src/lando/headless_api/tests/test_automation_api.py
+++ b/src/lando/headless_api/tests/test_automation_api.py
@@ -368,6 +368,37 @@ def test_automation_job_create_api(client, hg_server, hg_clone, headless_user):
 
 
 @pytest.mark.django_db
+def test_automation_job_create_commit_request(client, repo_mc, headless_user):
+    user, token = headless_user
+
+    repo = repo_mc(SCM_TYPE_GIT)
+    body = {
+        "actions": [
+            {
+                "action": "create-commit",
+                "commitmsg": "test commit message",
+                "date": "2025-04-22T18:30:27.786900+00:00",
+                "author": "Test User <test@example.com>",
+                "diff": "diff --git",
+            }
+        ],
+    }
+    response = client.post(
+        f"/api/repo/{repo.name}",
+        data=json.dumps(body),
+        content_type="application/json",
+        headers={
+            "User-Agent": "Lando-User/testuser@example.org",
+            "Authorization": f"Bearer {token}",
+        },
+    )
+
+    assert (
+        response.status_code == 202
+    ), "Successful submission should result in `202 Accepted` status code."
+
+
+@pytest.mark.django_db
 def test_get_job_status_not_found(client, headless_user):
     user, token = headless_user
     response = client.get(


### PR DESCRIPTION
Using `.dict()` converts the Pydantic models to a `dict`, but does
not properly convert Python types like `datetime` into a JSON
serializeable format. Switch to using `.model_dump(mode="json")`
which does the correct conversion.
