### PR TITLE
phabricator: support limits when collating (bug 1957891)

### DIFF
--- a/src/lando/api/legacy/api/transplants.py
+++ b/src/lando/api/legacy/api/transplants.py
@@ -397,7 +397,7 @@ def get_list(
         return problem(404, "Revision not found", HTTP_404_STRING)
     nodes, edges = build_stack_graph(revision)
     revision_phids = list(nodes)
-    revs = phab.call_conduit(
+    revs = phab.call_conduit_collated(
         "differential.revision.search",
         constraints={"phids": revision_phids},
         limit=len(revision_phids),

--- a/src/lando/utils/phabricator.py
+++ b/src/lando/utils/phabricator.py
@@ -214,6 +214,15 @@ class PhabricatorClient:
 
     def call_conduit_collated(self, method: str, **kwargs) -> dict[str, list[Any]]:
         """Continuously call call_conduit and return the collated data in one dict."""
+
+        # NOTE: if a limit is passed, it is ignored since Phabricator already limits
+        # results to 100, and raises and error if a limit is passed that is greater
+        # than 100. This is kept for backwards compatibility.
+        # See bug 1962523 for more information.
+        limit = None
+        if "limit" in kwargs:
+            limit = kwargs.pop("limit")
+
         result = self.call_conduit(method, **kwargs)
         if not result:
             return {"data": []}
@@ -225,6 +234,8 @@ class PhabricatorClient:
             )
             if result and "data" in result and result["data"]:
                 data += result["data"]
+        if limit:
+            data = data[:limit]
         return {"data": data}
 
     @staticmethod


### PR DESCRIPTION
- ignore limit when calling call_conduit
- return data based on original limit after collating

For queries that are expected to return greater than 100 results
setting the limit does not make sense as Phabricator limits results
to 100 anyway. So in those cases, we ignore the limit set, and then
discard any excess records. This is done for compatibility at this
time since various methods currently set a limit.