### PR TITLE
create_environment_repos: remove prod repos from script (bug 1959193)

### DIFF
--- a/src/lando/utils/management/commands/create_environment_repos.py
+++ b/src/lando/utils/management/commands/create_environment_repos.py
@@ -5,15 +5,13 @@ from django.db.utils import IntegrityError
 from lando.environments import Environment
 from lando.main.models import (
     DONTBUILD,
-    SCM_ALLOW_DIRECT_PUSH,
     SCM_CONDUIT,
     SCM_LEVEL_1,
-    SCM_LEVEL_3,
     Repo,
 )
 from lando.main.scm import GitSCM
 
-ENVIRONMENTS = [e for e in Environment if not e.is_test]
+ENVIRONMENTS = [e for e in Environment if not e.is_test and e.is_lower]
 
 # These repos are copied from the legacy repo "subsystem".
 REPOS = {
@@ -167,20 +165,6 @@ for branch in ["main", "autoland", "beta", "release", "esr115", "esr128"]:
             "short_name": f"staging-firefox-{branch}",
             "required_permission": SCM_LEVEL_1,
             "automation_enabled": True,
-        }
-    )
-
-for branch in ["main"]:
-    REPOS[Environment.production].append(
-        {
-            "name": f"firefox-{branch}",
-            "default_branch": branch,
-            "url": "https://github.com/mozilla-firefox/firefox.git",
-            "push_path": "https://github.com/mozilla-firefox/firefox.git",
-            "short_name": f"firefox-{branch}",
-            "required_permission": (
-                SCM_ALLOW_DIRECT_PUSH if branch != "autoland" else SCM_LEVEL_3
-            ),
         }
     )
 


### PR DESCRIPTION
These repos are no longer needed in the script, since it has already been run.