### PR TITLE
create_environment_repos: create `firefox-main` repo in Lando (Bug 1963410)

### DIFF
--- a/src/lando/utils/management/commands/create_environment_repos.py
+++ b/src/lando/utils/management/commands/create_environment_repos.py
@@ -156,7 +156,7 @@ REPOS = {
     Environment.production: [],
 }
 
-for branch in ["autoland", "beta", "esr115", "esr128", "release"]:
+for branch in ["main"]:
     REPOS[Environment.production].append(
         {
             "name": f"firefox-{branch}",


### PR DESCRIPTION
Remove the already-created repos and only create the `main` repo in
`create_environment_repos`.
