### PR TITLE
uplift: pass empty tree hash when creating diff (bug 1963679)

### DIFF
--- a/src/lando/api/legacy/uplift.py
+++ b/src/lando/api/legacy/uplift.py
@@ -330,6 +330,7 @@ def create_uplift_revision(
                         phab.expect(commit, "message")
                     ),
                     "commit": phab.expect(commit, "identifier"),
+                    "tree": "0000000000000000000000000000000000000000",
                     "rev": phab.expect(commit, "identifier"),
                     "parents": [base_revision],
                 }


### PR DESCRIPTION
- Phabricator expects this value to be set for git commits
- Mercurial commits that are copied over do not include this value

See [bug 1963689](https://bugzilla.mozilla.org/show_bug.cgi?id=1963689) for full fix.