### PR TITLE
git: only force a `--no-ff` merge when strategy is explicitly passed (Bug 1963699)

### DIFF
--- a/src/lando/headless_api/tests/test_automation_api.py
+++ b/src/lando/headless_api/tests/test_automation_api.py
@@ -829,16 +829,16 @@ def test_automation_job_merge_onto_fast_forward_git(
 
     repo_path = Path(repo.system_path)
 
-    # Start on main, make a commit
+    # Start on main, make a commit.
     subprocess.run(["git", "switch", "main"], cwd=repo_path, check=True)
     _create_git_commit(request, repo_path)
 
-    # Create feature branch from main, add another commit
+    # Create feature branch from main, add another commit.
     subprocess.run(["git", "switch", "-c", "feature"], cwd=repo_path, check=True)
     _create_git_commit(request, repo_path)
     feature_sha = scm.head_ref()
 
-    # Return to base (fast-forward target)
+    # Return to base (fast-forward target).
     subprocess.run(["git", "switch", "main"], cwd=repo_path, check=True)
 
     job = AutomationJob.objects.create(

--- a/src/lando/main/scm/git.py
+++ b/src/lando/main/scm/git.py
@@ -539,11 +539,10 @@ class GitSCM(AbstractSCM):
             return new_merge_commit
 
         # Set strategy args.
-        strategy_args = ["-s", strategy] if strategy else []
+        strategy_args = ["--no-ff", "-s", strategy] if strategy else []
 
         self._git_run(
             "merge",
-            "--no-ff",
             "-m",
             commit_message,
             *strategy_args,

--- a/src/lando/main/tests/test_git.py
+++ b/src/lando/main/tests/test_git.py
@@ -518,19 +518,19 @@ def test_GitSCM_merge_onto_fast_forward(
     scm.clone(str(git_repo))
     git_setup_user(str(clone_path))
 
-    # Create base commit on main
+    # Create base commit on main.
     _create_git_commit(request, clone_path)
 
-    # Create a feature branch and add a commit
+    # Create a feature branch and add a commit.
     subprocess.run(["git", "switch", "-c", "feature"], cwd=clone_path, check=True)
     _create_git_commit(request, clone_path)
     feature_commit = scm.head_ref()
 
-    # Switch back to base
+    # Switch back to base.
     subprocess.run(["git", "switch", "main"], cwd=clone_path, check=True)
     base_commit = scm.head_ref()
 
-    # Merge (should fast-forward)
+    # Merge (should fast-forward).
     commit_msg = "Fast-forward merge"
     new_head = scm.merge_onto(commit_msg, feature_commit, strategy=None)
 
@@ -548,7 +548,7 @@ def test_GitSCM_merge_onto_fast_forward(
         scm.head_ref() != base_commit
     ), "Returned head for `main` should not point to the old base."
 
-    # Check that no merge commit was created
+    # Check that no merge commit was created.
     parents = (
         subprocess.run(
             ["git", "rev-list", "--parents", "-n", "1", new_head],
@@ -563,7 +563,7 @@ def test_GitSCM_merge_onto_fast_forward(
 
     assert (
         len(parents) == 2
-    ), "Fast-forward should have one parent (i.e. no merge commit)"
+    ), "Fast-forward should have one parent (i.e. no merge commit)."
 
 
 def test_GitSCM_tag(


### PR DESCRIPTION
Currently we have been forcing `--no-ff` merges in `GitSCM.merge_onto`.
When possible, we want to allow fast-foward merges to take place.
Update `merge_onto` to only enforce `--no-ff` when using a merge
strategy, since in that case the strategy will be avoided when
a fast-foward is possible, so the strategy will be ignored.
