### PR TITLE
create_environment_repo: add releng staging branches (bug 1964674)

### DIFF
--- a/src/lando/utils/management/commands/create_environment_repos.py
+++ b/src/lando/utils/management/commands/create_environment_repos.py
@@ -156,6 +156,20 @@ REPOS = {
     Environment.production: [],
 }
 
+# RelEng staging repo / branches - used in try pushes
+for branch in ["main", "autoland", "beta", "release", "esr115", "esr128"]:
+    REPOS[Environment.staging].append(
+        {
+            "name": f"staging-firefox-{branch}",
+            "default_branch": branch,
+            "url": "https://github.com/mozilla-releng/staging-firefox.git",
+            "push_path": "https://github.com/mozilla-releng/staging-firefox.git",
+            "short_name": f"staging-firefox-{branch}",
+            "required_permission": SCM_LEVEL_1,
+            "automation_enabled": True,
+        }
+    )
+
 for branch in ["main"]:
     REPOS[Environment.production].append(
         {


### PR DESCRIPTION
This will allow RelEng to have a set of dedicated repositories that we can write to as part of Try tasks to verify our own automation, that we'll also be able to force push to/reset as needed.

We explicitly do _not_ want to sync these back to hg to avoid any complications when we force push to them.

I ended up using scm level 1 for these, since they are Try-oriented repositories.