### PR TITLE
uplifts: use `repo.default_branch` as repo name for uplifts (Bug 1963870)

### DIFF
--- a/src/lando/api/legacy/workers/landing_worker.py
+++ b/src/lando/api/legacy/workers/landing_worker.py
@@ -209,7 +209,10 @@ class LandingWorker(Worker):
             try:
                 # If we just landed an uplift, update the relevant bugs as appropriate.
                 update_bugs_for_uplift(
-                    repo.short_name,
+                    # Use the `legacy source` shortname here, since the new repos
+                    # use the `firefox-` prefix naming convention. For `firefox-beta`
+                    # this should return `beta`, etc.
+                    repo.default_branch,
                     scm.read_checkout_file("config/milestone.txt"),
                     repo.milestone_tracking_flag_template,
                     bug_ids,


### PR DESCRIPTION
Use `repo.default_branch` as the repo name for Bugzilla
updates on uplift. In the new unified Git repo model,
the branch names map to the expected values in BMO
for tracking flags.
