### PR TITLE
hgexports: use bytes when initializing email message (bug 1969532)

### DIFF
--- a/src/lando/api/legacy/hgexports.py
+++ b/src/lando/api/legacy/hgexports.py
@@ -302,8 +302,9 @@ class GitPatchHelper(PatchHelper):
 
     def __init__(self, fileobj: io.StringIO):
         super().__init__(fileobj)
-        self.message = email.message_from_string(
-            self.patch.read(), policy=default_email_policy
+        message_bytes = fileobj.read().encode("utf-8")
+        self.message = email.message_from_bytes(
+            message_bytes, policy=default_email_policy
         )
         self.message.set_charset("utf-8")
         self.commit_message, self.diff = self.parse_email_body(

--- a/src/lando/api/tests/test_hgexports.py
+++ b/src/lando/api/tests/test_hgexports.py
@@ -162,6 +162,10 @@ From 71ce7889eaa24616632a455636598d8f5c60b765 Mon Sep 17 00:00:00 2001
 From: Connor Sheehan <sheehan@mozilla.com>
 Date: Wed, 21 Feb 2024 10:20:49 +0000
 Subject: [PATCH] Bug 1874040 - Move 1103348-1.html to WPT, and expand it.
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
  r=smaug
 
 ---


### PR DESCRIPTION
- work around issue with `email.message.get_content` corrupting message with unexpected characters
- add headers to test patch to make sure the correct code paths are triggered in the test