### PR TITLE
git: add `-f` to `git add` call in `apply_patch` (Bug 1970574)

### DIFF
--- a/src/lando/main/scm/git.py
+++ b/src/lando/main/scm/git.py
@@ -188,7 +188,8 @@ class GitSCM(AbstractSCM):
 
             cmds = [
                 ["apply", "--reject", f_diff.name],
-                ["add", "-A"],
+                # Use `-f` here to include files in `.gitignore`.
+                ["add", "-A", "-f"],
                 [
                     "commit",
                     "--date",


### PR DESCRIPTION
When applying patches to Git repos in Lando, we apply the patch
with `git apply` and then add the new files to the index with
`git add`. Using this strategy means the `.gitignore` file in
the repo is respected and files that are ignored will not be
added to the patch. Add `-f` to the `git add` call so ignored
files are also included in the index before committing. This
aligns with how `HgSCM.apply_patch` works as we directly apply
patches without considering `.hgignore`.
