### PR TITLE
git: use `git rev-parse --is-inside-work-tree` to check repo initialization (Bug 1972441)

### DIFF
--- a/src/lando/main/scm/git.py
+++ b/src/lando/main/scm/git.py
@@ -449,11 +449,11 @@ class GitSCM(AbstractSCM):
             return False
 
         try:
-            self._git_run("status", cwd=self.path)
+            result = self._git_run("rev-parse", "--is-inside-work-tree", cwd=self.path)
         except SCMException:
             return False
 
-        return True
+        return result.strip() == "true"
 
     @classmethod
     def repo_is_supported(cls, path: str) -> bool:


### PR DESCRIPTION
`repo_is_initialized` is used to determine if the Git repo has
been initialized yet, or if it should be cloned. Our current
implementation of running `git status` is slow, adding about
20 minutes to the automation worker startup time before automation
jobs can be run. Switch to using `git rev-parse --is-inside-work-tree`,
which performs the same function for our purposes while being much
faster to execute.
