### PR TITLE
tests: add fixtures to mock out `phab_trigger_repo_update` for workers (Bug 1969192)

### DIFF
--- a/src/lando/conftest.py
+++ b/src/lando/conftest.py
@@ -2,6 +2,7 @@ import pathlib
 import re
 import subprocess
 import time
+import unittest.mock as mock
 from collections.abc import Callable
 from datetime import datetime, timezone
 from pathlib import Path
@@ -888,3 +889,25 @@ def assert_same_commit_data():
         assert set(commit.files) == set(scm_commit.files)
 
     return assertion
+
+
+@pytest.fixture
+def mock_landing_worker_phab_repo_update(monkeypatch):
+    mock_trigger_update = mock.MagicMock()
+    monkeypatch.setattr(
+        "lando.api.legacy.workers.landing_worker.LandingWorker.phab_trigger_repo_update",
+        mock_trigger_update,
+    )
+
+    return mock_trigger_update
+
+
+@pytest.fixture
+def mock_automation_worker_phab_repo_update(monkeypatch):
+    mock_trigger_update = mock.MagicMock()
+    monkeypatch.setattr(
+        "lando.api.legacy.workers.automation_worker.AutomationWorker.phab_trigger_repo_update",
+        mock_trigger_update,
+    )
+
+    return mock_trigger_update

--- a/src/lando/headless_api/tests/test_automation_api.py
+++ b/src/lando/headless_api/tests/test_automation_api.py
@@ -525,7 +525,7 @@ def test_automation_job_add_commit_success_hg(
     treestatusdouble,
     hg_automation_worker,
     repo_mc,
-    monkeypatch,
+    mock_automation_worker_phab_repo_update,
     normal_patch,
     automation_job,
 ):
@@ -550,13 +550,6 @@ def test_automation_job_add_commit_success_hg(
 
     hg_automation_worker.worker_instance.applicable_repos.add(repo)
 
-    # Mock `phab_trigger_repo_update` so we can make sure that it was called.
-    mock_trigger_update = mock.MagicMock()
-    monkeypatch.setattr(
-        "lando.api.legacy.workers.automation_worker.AutomationWorker.phab_trigger_repo_update",
-        mock_trigger_update,
-    )
-
     scm.push = mock.MagicMock()
 
     assert hg_automation_worker.run_automation_job(job)
@@ -574,7 +567,7 @@ def test_automation_job_add_commit_success_git(
     treestatusdouble,
     git_automation_worker,
     repo_mc,
-    monkeypatch,
+    mock_automation_worker_phab_repo_update,
     git_patch,
     automation_job,
 ):
@@ -597,13 +590,6 @@ def test_automation_job_add_commit_success_git(
 
     git_automation_worker.worker_instance.applicable_repos.add(repo)
 
-    # Mock `phab_trigger_repo_update` so we can make sure that it was called.
-    mock_trigger_update = mock.MagicMock()
-    monkeypatch.setattr(
-        "lando.api.legacy.workers.automation_worker.AutomationWorker.phab_trigger_repo_update",
-        mock_trigger_update,
-    )
-
     scm.push = mock.MagicMock()
 
     assert git_automation_worker.run_automation_job(job)
@@ -620,7 +606,7 @@ def test_automation_job_add_commit_base64_success_git(
     treestatusdouble,
     git_automation_worker,
     repo_mc,
-    monkeypatch,
+    mock_automation_worker_phab_repo_update,
     git_patch,
     automation_job,
 ):
@@ -647,13 +633,6 @@ def test_automation_job_add_commit_base64_success_git(
 
     git_automation_worker.worker_instance.applicable_repos.add(repo)
 
-    # Mock `phab_trigger_repo_update` so we can make sure that it was called.
-    mock_trigger_update = mock.MagicMock()
-    monkeypatch.setattr(
-        "lando.api.legacy.workers.automation_worker.AutomationWorker.phab_trigger_repo_update",
-        mock_trigger_update,
-    )
-
     scm.push = mock.MagicMock()
 
     assert git_automation_worker.run_automation_job(job)
@@ -672,7 +651,7 @@ def test_automation_job_add_commit_fail(
     repo_mc,
     treestatusdouble,
     hg_automation_worker,
-    monkeypatch,
+    mock_automation_worker_phab_repo_update,
     automation_job,
 ):
     repo = repo_mc(SCM_TYPE_GIT)
@@ -694,13 +673,6 @@ def test_automation_job_add_commit_fail(
 
     hg_automation_worker.worker_instance.applicable_repos.add(repo)
 
-    # Mock `phab_trigger_repo_update` so we can make sure that it was called.
-    mock_trigger_update = mock.MagicMock()
-    monkeypatch.setattr(
-        "lando.api.legacy.workers.automation_worker.AutomationWorker.phab_trigger_repo_update",
-        mock_trigger_update,
-    )
-
     scm.push = mock.MagicMock()
 
     assert not hg_automation_worker.run_automation_job(job)
@@ -715,7 +687,7 @@ def test_automation_job_create_commit_success(
     repo_mc,
     treestatusdouble,
     get_automation_worker,
-    monkeypatch,
+    mock_automation_worker_phab_repo_update,
     get_failing_check_diff,
     automation_job,
 ):
@@ -741,13 +713,6 @@ def test_automation_job_create_commit_success(
     automation_worker = get_automation_worker(scm_type)
 
     automation_worker.worker_instance.applicable_repos.add(repo)
-
-    # Mock `phab_trigger_repo_update` so we can make sure that it was called.
-    mock_trigger_update = mock.MagicMock()
-    monkeypatch.setattr(
-        "lando.api.legacy.workers.automation_worker.AutomationWorker.phab_trigger_repo_update",
-        mock_trigger_update,
-    )
 
     scm.push = mock.MagicMock()
 
@@ -776,7 +741,7 @@ def test_automation_job_create_commit_failed_check(
     repo_mc,
     treestatusdouble,
     get_automation_worker,
-    monkeypatch,
+    mock_automation_worker_phab_repo_update,
     get_failing_check_action_reason: Callable,
     bad_action_type: str,
     hooks_enabled: bool,
@@ -804,13 +769,6 @@ def test_automation_job_create_commit_failed_check(
     automation_worker = get_automation_worker(scm_type)
 
     automation_worker.worker_instance.applicable_repos.add(repo)
-
-    # Mock `phab_trigger_repo_update` so we can make sure that it was called.
-    mock_trigger_update = mock.MagicMock()
-    monkeypatch.setattr(
-        "lando.api.legacy.workers.automation_worker.AutomationWorker.phab_trigger_repo_update",
-        mock_trigger_update,
-    )
 
     scm.push = mock.MagicMock()
 
@@ -858,7 +816,7 @@ def test_automation_job_create_commit_failed_check_override(
     repo_mc,
     treestatusdouble,
     get_automation_worker,
-    monkeypatch,
+    mock_automation_worker_phab_repo_update,
     get_failing_check_action_reason: Callable,
     get_failing_check_diff,
     automation_job,
@@ -886,13 +844,6 @@ def test_automation_job_create_commit_failed_check_override(
     automation_worker = get_automation_worker(scm_type)
 
     automation_worker.worker_instance.applicable_repos.add(repo)
-
-    # Mock `phab_trigger_repo_update` so we can make sure that it was called.
-    mock_trigger_update = mock.MagicMock()
-    monkeypatch.setattr(
-        "lando.api.legacy.workers.automation_worker.AutomationWorker.phab_trigger_repo_update",
-        mock_trigger_update,
-    )
 
     scm.push = mock.MagicMock()
 


### PR DESCRIPTION
Add fixtures to mock out the `phab_trigger_repo_update` method on
the landing and automation workers. We currently add this code
snippet to many tests manually, so this fixture allows us to mock
out the call to create a new Celery job without polluting the test
with irrelevant mocks.
