### PR TITLE
scm: remove `get_current_node` in favour of `head_ref` (Bug 1961081)

### DIFF
--- a/src/lando/main/scm/git.py
+++ b/src/lando/main/scm/git.py
@@ -433,7 +433,7 @@ class GitSCM(AbstractSCM):
     def format_stack_amend(self) -> Optional[list[str]]:
         """Amend the top commit in the patch stack with changes from formatting."""
         self._git_run("commit", "--all", "--amend", "--no-edit", cwd=self.path)
-        return [self.get_current_node()]
+        return [self.head_ref()]
 
     def format_stack_tip(self, commit_message: str) -> Optional[list[str]]:
         """Add an autoformat commit to the top of the patch stack."""
@@ -444,11 +444,7 @@ class GitSCM(AbstractSCM):
                 return []
             else:
                 raise exc
-        return [self.get_current_node()]
-
-    def get_current_node(self) -> str:
-        """Return the commit_id of the tip of the current branch."""
-        return self._git_run("rev-parse", "HEAD", cwd=self.path)
+        return [self.head_ref()]
 
     @property
     def repo_is_initialized(self) -> bool:
@@ -577,7 +573,7 @@ class GitSCM(AbstractSCM):
                 cwd=self.path,
             )
 
-            new_merge_commit = self.get_current_node()
+            new_merge_commit = self.head_ref()
 
             # Move the original branch to point to the merge commit
             self._git_run(
@@ -599,7 +595,7 @@ class GitSCM(AbstractSCM):
             cwd=self.path,
         )
 
-        return self.get_current_node()
+        return self.head_ref()
 
     def tag(self, name: str, target: str | None):
         """Create a new tag called `name` on the `target` commit.

--- a/src/lando/main/scm/hg.py
+++ b/src/lando/main/scm/hg.py
@@ -502,7 +502,7 @@ class HgSCM(AbstractSCM):
             # Amend the current commit, using `--no-edit` to keep the existing commit message.
             self.run_hg(["commit", "--amend", "--no-edit", "--landing_system", "lando"])
 
-            return [self.get_current_node().decode("utf-8")]
+            return [self.head_ref()]
         except HgCommandError as exc:
             if "nothing changed" in exc.out:
                 # If nothing changed after formatting we can just return.
@@ -523,7 +523,7 @@ class HgSCM(AbstractSCM):
                 + ["--landing_system", "lando"]
             )
 
-            return [self.get_current_node().decode("utf-8")]
+            return [self.head_ref()]
 
         except HgCommandError as exc:
             if "nothing changed" in exc.out:
@@ -531,10 +531,6 @@ class HgSCM(AbstractSCM):
                 return
 
             raise exc
-
-    def get_current_node(self) -> bytes:
-        """Return the currently checked out node."""
-        return self.run_hg(["identify", "-r", ".", "-i"])
 
     def clone(self, source: str):
         """Clone a repository from a source."""
@@ -717,7 +713,7 @@ class HgSCM(AbstractSCM):
 
         self.run_hg(["commit", "-m", commit_message, "--landing_system", "lando"])
 
-        return self.get_current_node().decode("utf-8")
+        return self.head_ref()
 
     def tag(self, name: str, target: str | None):
         """Create a new tag called `name` on the `target` commit.


### PR DESCRIPTION
These methods perform the same function. As `head_ref` is
older, remove `get_current_node` and convert usages to
`head_ref`. The method was never added to `AbstractSCM`
so this change is only required in `HgSCM` and `GitSCM`.
