### PR TITLE
uplift: disable `Request Uplift` button when stack is too large (Bug 1975458)

### DIFF
--- a/src/lando/ui/jinja2/stack/stack.html
+++ b/src/lando/ui/jinja2/stack/stack.html
@@ -188,6 +188,18 @@
         <section class="modal-card-body">
           <input type="hidden" name="revision_id" value="{{ revision_id }}" />
 
+          {% if uplift_stack_too_large %}
+            <article class="message is-danger">
+              <div class="message-header">
+                <p>Uplift Blocked</p>
+              </div>
+              <div class="message-body">
+                This stack contains {{ series|length }} revisions, which exceeds the maximum allowed for web-based uplift ({{ max_uplift_stack_size }}).
+                Please use the <code>moz-phab uplift</code> command-line tool instead.
+              </div>
+            </article>
+          {% endif %}
+
           <p class="block">
             Select the repository you wish to uplift this revision to.
             Once you submit the request, you will be redirected to the new uplift revision on Phabricator.
@@ -215,11 +227,12 @@
         </section>
 
         <footer class="modal-card-foot">
-          <button
-            class="button is-success"
-            title="Create Phabricator review requests for the selected patch stack to land in the specified uplift train." >
-            Create uplift request
-          </button>
+            <button
+              class="button is-success"
+              {% if uplift_stack_too_large %}disabled{% endif %}
+              title="{% if uplift_stack_too_large %}Stack too large for web-based uplift. Use `moz-phab uplift` instead.{% else %}Create Phabricator review requests for the selected patch stack to land in the specified uplift train.{% endif %}">
+              Create uplift request
+            </button>
         </footer>
 
         </form>

--- a/src/lando/ui/legacy/revisions.py
+++ b/src/lando/ui/legacy/revisions.py
@@ -7,6 +7,7 @@ from django.shortcuts import redirect
 from django.template.response import TemplateResponse
 
 from lando.api.legacy import api as legacy_api
+from lando.api.legacy.uplift import MAX_UPLIFT_STACK_SIZE
 from lando.main.auth import force_auth_refresh
 from lando.main.models import Repo
 from lando.ui.legacy.forms import (
@@ -164,6 +165,9 @@ class Revision(LandoView):
         else:
             existing_flags = {}
 
+        # Check if the stack is larger than our maximum upliftable stack size.
+        uplift_stack_too_large = series and len(series) > MAX_UPLIFT_STACK_SIZE
+
         context = {
             "revision_id": "D{}".format(revision_id),
             "series": series,
@@ -181,6 +185,8 @@ class Revision(LandoView):
             "flags": target_repo.commit_flags if target_repo else [],
             "existing_flags": existing_flags,
             "uplift_request_form": uplift_request_form,
+            "uplift_stack_too_large": uplift_stack_too_large,
+            "max_uplift_stack_size": MAX_UPLIFT_STACK_SIZE,
         }
 
         return TemplateResponse(


### PR DESCRIPTION
Before rendering the stack landing page, check the size of the series
against the max uplift size. Pass this check and the max uplift size
to the template and render a disabled button with a warning if the
stack size is too large.
