### PR TITLE
stack: show `Request Uplift` button unconditionally and warn for missing API key (Bug 1934923)

### DIFF
--- a/src/lando/ui/jinja2/stack/stack.html
+++ b/src/lando/ui/jinja2/stack/stack.html
@@ -113,11 +113,11 @@
         <button class="StackPage-preview-button">
           <div class="StackPage-actions-headline">Preview Landing</div>
         </button>
+        <button class="button uplift-request-open is-normal">
+            <span class="icon"><i class="fa fa-arrow-circle-up"></i></span>
+            <div class="StackPage-actions-headline">Request Uplift</span>
+        </button>
       {% endif %}
-      <button class="button uplift-request-open is-normal">
-          <span class="icon"><i class="fa fa-arrow-circle-up"></i></span>
-          <div class="StackPage-actions-headline">Request Uplift</span>
-      </button>
   </div>
 
   {% if user_is_authenticated %}


### PR DESCRIPTION
Change the "Request Uplift" button to always display for an authenticated user.
When the modal is displayed, check for a missing API token and show a warning
that the API key is required, while disabling the "Create uplift request"
button.
