### PR TITLE
stack: always display "Request Uplift" button when user is logged in (Bug 1976527)

### DIFF
--- a/src/lando/ui/jinja2/stack/stack.html
+++ b/src/lando/ui/jinja2/stack/stack.html
@@ -113,6 +113,9 @@
         <button class="StackPage-preview-button">
           <div class="StackPage-actions-headline">Preview Landing</div>
         </button>
+      {% endif %}
+
+      {% if user_is_authenticated %}
         <button class="button uplift-request-open is-normal">
             <span class="icon"><i class="fa fa-arrow-circle-up"></i></span>
             <div class="StackPage-actions-headline">Request Uplift</span>


### PR DESCRIPTION
At the moment the button only displays when the "Preview Landing" button
is displayed. "Preview Landing" is only displayed when the landing is
valid, which means that if a revision is closed and the user is missing
their Phabricator API key, the button will not display.

Move the "Request Uplift" button to a separate `if` block that only
checks if the user is logged in.
