### PR TITLE
utils: use raw query to pause workers for maintenance (bug 1945758)

### DIFF
--- a/src/lando/utils/management/commands/maintenance.py
+++ b/src/lando/utils/management/commands/maintenance.py
@@ -23,7 +23,7 @@ class Command(BaseCommand):
     def _pause_workers(self):
         """Pause all workers."""
         # We explicitely select the `is_paused` field, and defer the others.
-        # This allows a new version of lando to Pause workers during an update, even
+        # This allows a new version of lando to pause workers during an update, even
         # with pending migrations in the Worker model, that would otherwise result in
         # UndefinedColumn errors if trying to fetch all (expected) fields.
         workers = Worker.objects.raw("SELECT id, is_paused from main_worker")

--- a/src/lando/utils/management/commands/maintenance.py
+++ b/src/lando/utils/management/commands/maintenance.py
@@ -22,7 +22,11 @@ class Command(BaseCommand):
 
     def _pause_workers(self):
         """Pause all workers."""
-        workers = Worker.objects.all()
+        # We explicitely select the `is_paused` field, and defer the others.
+        # This allows a new version of lando to Pause workers during an update, even
+        # with pending migrations in the Worker model, that would otherwise result in
+        # UndefinedColumn errors if trying to fetch all (expected) fields.
+        workers = Worker.objects.raw("SELECT id, is_paused from main_worker")
         for worker in workers:
             worker.pause()
             self.stdout.write(f"Paused {worker}.")


### PR DESCRIPTION
This is necessary as a requirements of the fix for bug 1945758. This allows us to update the worker database schemas. Without this deployments will fail as the maintenance mode is switched on, and new columns are fetched from the yet unmigrated database, leading to failures.