### PR TITLE
landing_worker: Add "--skip-android" to "./mach format" call (Bug 1979992)

### DIFF
--- a/src/lando/api/legacy/workers/landing_worker.py
+++ b/src/lando/api/legacy/workers/landing_worker.py
@@ -530,7 +530,7 @@ class LandingWorker(Worker):
         are not committed into version control.
         """
         return self.run_mach_command(
-            path, ["format", "--fix", "--outgoing", "--verbose"]
+            path, ["format", "--fix", "--outgoing", "--verbose", "--skip-android"]
         )
 
     def run_mach_command(self, path: str, args: list[str]) -> str:


### PR DESCRIPTION
This does not change existing behavior. This just maintains compatibility with [D257609](https://phabricator.services.mozilla.com/D257609). See commit description in [D259154](https://phabricator.services.mozilla.com/D259154) and/or bug summary in [1979992](https://bugzilla.mozilla.org/show_bug.cgi?id=1979992) for a more thorough explanation.