### PR TITLE
compose: mount staticfiles in nginx proxy (bug 1981857)

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -72,6 +72,8 @@ services:
       - 443:443
     depends_on:
       - lando
+    volumes:
+      - ./staticfiles:/code/staticfiles
 
   redis:
     image: redis:7.2


### PR DESCRIPTION
Unlike the `lando` service, where we mount the whole codebase, nothing was mounted into the `proxy`.

Therefore, it could not find the staticfiles as directed by the `nginx` configuration.