### PR TITLE
jinja: add `ERROR` message level to notification class mapping (Bug 1982737)

### DIFF
--- a/src/lando/jinja.py
+++ b/src/lando/jinja.py
@@ -362,6 +362,7 @@ def message_type_to_notification_class(flash_message_category: str) -> str:
         levels["INFO"]: "is-info",
         levels["SUCCESS"]: "is-success",
         levels["WARNING"]: "is-warning",
+        levels["ERROR"]: "is-danger",
     }.get(flash_message_category, "is-info")
 
 


### PR DESCRIPTION
Map `ERROR` flash message to the Bulma `is-danger` CSS modifier.
