### PR TITLE
settings: add ninja to INSTALLED_APPS (bug 1980182)

### DIFF
--- a/src/lando/settings.py
+++ b/src/lando/settings.py
@@ -74,6 +74,7 @@ INSTALLED_APPS = [
     "django.contrib.staticfiles",
     "compressor",
     "mozilla_django_oidc",
+    "ninja",
 ]
 
 MIDDLEWARE = [


### PR DESCRIPTION
This is necessary so the static assets for the OpenAPI doc to be generated.