### PR TITLE
admin: add search_fields for most pages (bug 1955972)

### DIFF
--- a/src/lando/headless_api/admin.py
+++ b/src/lando/headless_api/admin.py
@@ -12,7 +12,12 @@ class ApiTokenAdmin(admin.ModelAdmin):
     # Mark these fields as read-only in the admin.
     readonly_fields = ("token_prefix", "token_hash", "created_at")
 
-    list_filter = ["created_at"]
+    search_fields = (
+        "token_prefix",
+        "user__email",
+    )
+
+    list_filter = ("created_at",)
 
     def user_email(self, instance: ApiToken) -> str:
         return instance.user.email
@@ -47,8 +52,8 @@ class AutomationJobAdmin(admin.ModelAdmin):
         "requester_email",
         "duration_seconds",
     )
-    list_filter = ("target_repo__name", "requester_email", "created_at")
-    inlines = [AutomationActionJobInline]
+    list_filter = ("target_repo__name", "created_at")
+    inlines = (AutomationActionJobInline,)
     readonly_fields = (
         "attempts",
         "duration_seconds",
@@ -59,6 +64,7 @@ class AutomationJobAdmin(admin.ModelAdmin):
         "relbranch_commit_sha",
         "target_repo",
     )
+    search_fields = ("requester_email",)
 
     def action_types(self, instance: AutomationJob) -> str:
         """Return a summary string of the action types associated to a given job."""
@@ -71,7 +77,8 @@ class AutomationActionAdmin(admin.ModelAdmin):
         "action_type",
         "job_id",
     )
-    readonly_fields = ["job_id"]
+    readonly_fields = ("job_id",)
+    search_fields = ("data",)
 
 
 admin.site.register(ApiToken, ApiTokenAdmin)

--- a/src/lando/main/admin.py
+++ b/src/lando/main/admin.py
@@ -61,7 +61,7 @@ class RevisionLandingJobInline(admin.TabularInline):
 
 class LandingJobAdmin(admin.ModelAdmin):
     model = LandingJob
-    inlines = [RevisionLandingJobInline]
+    inlines = (RevisionLandingJobInline,)
     list_display = (
         "id",
         "status",
@@ -70,7 +70,7 @@ class LandingJobAdmin(admin.ModelAdmin):
         "requester_email",
         "duration_seconds",
     )
-    list_filter = ["target_repo__name", "requester_email", "created_at"]
+    list_filter = ("target_repo__name", "created_at")
     fields = (
         "status",
         "attempts",
@@ -83,13 +83,14 @@ class LandingJobAdmin(admin.ModelAdmin):
         "target_commit_hash",
         "target_repo",
     )
-    readonly_fields = [
+    readonly_fields = (
         "attempts",
         "duration_seconds",
         "error",
         "formatted_replacements",
         "landed_commit_id",
-    ]
+    )
+    search_fields = ("requester_email", "unsorted_revisions__revision_id")
 
 
 class RevisionAdmin(admin.ModelAdmin):
@@ -100,6 +101,7 @@ class RevisionAdmin(admin.ModelAdmin):
         "patch_timestamp",
         "author",
     )
+    search_fields = ("revision_id",)
 
     def revision(self, instance: Revision) -> str:
         """Return a Phabricator-like revision identifier."""
@@ -155,6 +157,8 @@ class RepoAdmin(admin.ModelAdmin):
         "scm_type",
     )
 
+    search_fields = ("pull_path", "push_path", "url")
+
 
 class CommitMapAdmin(admin.ModelAdmin):
     model = CommitMap
@@ -163,12 +167,20 @@ class CommitMapAdmin(admin.ModelAdmin):
         "git_hash",
         "hg_hash",
     )
-    list_filter = ["git_repo_name"]
+    list_filter = ("git_repo_name",)
+    search_fields = (
+        "git_hash",
+        "hg_hash",
+    )
 
 
 class ConfigurationVariableAdmin(admin.ModelAdmin):
     model = ConfigurationVariable
     list_display = (
+        "key",
+        "value",
+    )
+    search_fields = (
         "key",
         "value",
     )
@@ -184,6 +196,7 @@ class WorkerAdmin(admin.ModelAdmin):
         "is_paused",
         "is_stopped",
     )
+    search_fields = ("applicable_repos__name",)
 
     def repo_count(self, instance: Worker) -> int:
         """Return the count of repositories associated to the Worker."""

--- a/src/lando/pushlog/admin.py
+++ b/src/lando/pushlog/admin.py
@@ -32,7 +32,7 @@ class PushCommitInline(ReadOnlyInline):
     # Used by ReadOnlyInline._field_getter_factory
     _target_object = "commit"
 
-    readonly_fields = ["hash_short", "desc", "author"]
+    readonly_fields = ("hash_short", "desc", "author")
 
     def hash_short(self, instance: Commit) -> str:
         return instance.commit.hash[:8]
@@ -47,7 +47,7 @@ class PushTagInline(ReadOnlyInline):
     # Used by ReadOnlyInline._field_getter_factory
     _target_object = "tag"
 
-    readonly_fields = ["name", "commit"]
+    readonly_fields = ("name", "commit")
 
 
 class PushAdmin(PushLogAdmin):
@@ -61,9 +61,9 @@ class PushAdmin(PushLogAdmin):
         "datetime",
         "user",
     )
-    inlines = [PushCommitInline, PushTagInline]
-    exclude = ["commits", "tags"]
-    list_display = [
+    inlines = (PushCommitInline, PushTagInline)
+    exclude = ("commits", "tags")
+    list_display = (
         "push_id",
         "notified",
         "repo__name",
@@ -72,8 +72,9 @@ class PushAdmin(PushLogAdmin):
         "tag_summary",
         "datetime",
         "user",
-    ]
-    list_filter = ["repo", "branch", "user", "datetime"]
+    )
+    list_filter = ("repo", "branch", "datetime")
+    search_fields = ("user", "commits__hash", "tags__name")
 
     def commit_summary(self, instance: Push) -> str:
         """Return a summary of commits present in a Push.
@@ -112,13 +113,13 @@ class CommitPushInline(ReadOnlyInline):
     model = Push.commits.through
     _target_object = "push"
 
-    readonly_fields = [
+    readonly_fields = (
         "push_id",
         "repo",
         "branch",
         "datetime",
         "user",
-    ]
+    )
 
 
 class CommitAdmin(PushLogAdmin):
@@ -133,9 +134,11 @@ class CommitAdmin(PushLogAdmin):
         "_files",
         "_parents",
     )
-    list_display = ["hash_short", "repo__name", "desc_first", "datetime", "author"]
-    list_filter = ["repo", "author", "datetime"]
-    inlines = [CommitPushInline]
+    search_fields = ("author", "hash", "desc")
+
+    list_display = ("hash_short", "repo__name", "desc_first", "datetime", "author")
+    list_filter = ("repo", "datetime")
+    inlines = (CommitPushInline,)
 
     def hash_short(self, instance: Commit) -> str:
         return instance.hash[:8]
@@ -149,8 +152,9 @@ class FileAdmin(PushLogAdmin):
         "repo",
         "name",
     )
-    list_display = ["name", "repo__name"]
-    list_filter = ["repo"]
+    search_fields = ("name",)
+    list_display = ("name", "repo__name")
+    list_filter = ("repo",)
 
 
 class TagPushInline(CommitPushInline):
@@ -164,9 +168,10 @@ class TagAdmin(PushLogAdmin):
         "name",
         "commit",
     )
-    list_display = ["name", "commit", "repo__name"]
-    list_filter = ["repo"]
-    inlines = [TagPushInline]
+    search_fields = ("name", "commit__hash")
+    list_display = ("name", "commit", "repo__name")
+    list_filter = ("repo",)
+    inlines = (TagPushInline,)
 
 
 admin.site.register(Push, PushAdmin)


### PR DESCRIPTION
Most notably, and allow to search Jobs and Revisions by revision_id (without the 'D' prefix). Also, move users from the filter liste to the search list.

Generally, the search will allow to filter the visible columns, but there are a few handy, yet not very discoverable options:
- full-description search for Pushlog Commits,
- full-data search for HeadlessApi Automation Actions, and
- repository name search for Workers.

Some of the searches are on unindexed columns, so they may be a bit slow, but we can deal with those as we find them.