### PR TITLE
forms: populate repository choices in `__init__` instead of in class definition (Bug 1985106)

### DIFF
--- a/src/lando/ui/legacy/forms.py
+++ b/src/lando/ui/legacy/forms.py
@@ -22,8 +22,13 @@ class UpliftRequestForm(forms.Form):
     )
     repository = forms.ChoiceField(
         widget=forms.Select(),
-        choices=((repo, repo) for repo in get_uplift_repositories()),
     )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        uplift_repos = get_uplift_repositories()
+        self.fields["repository"].choices = [(repo, repo) for repo in uplift_repos]
 
     def clean_repository(self) -> str:
         repo_short_name = self.cleaned_data["repository"]


### PR DESCRIPTION
The `repository` field on the `UpliftRequestForm` currently has its
`choices` field defined as the result of the `get_uplift_repositories`
method. However the choices are set at class definition time, meaning
whatever is returned by `get_uplift_repositories` during a Lando deploy
are the choices set for every instantiation of the `UpliftRequestForm`.
If `get_uplift_repositories` doesn't return the proper results (due to
a Phabricator operational issue, network issue, etc) then the form will
have no repositories available as choices. Also, if an uplift repo is
added to Phabricator, it won't be made available until Lando is
re-deployed.

Move population of the `choices` parameter from the class definition
into `__init__` so the choices are determined when the form is
instantiated.
