### PR TITLE
workers: move shared logic to BaseWorker (bug 1958894)

### DIFF
--- a/src/lando/api/legacy/workers/base.py
+++ b/src/lando/api/legacy/workers/base.py
@@ -7,7 +7,6 @@ import os
 import re
 import subprocess
 from time import sleep
-from typing import Optional
 
 import lando.utils.treestatus
 from lando.main.models import Worker as WorkerModel
@@ -20,7 +19,7 @@ class Worker:
 
     SSH_PRIVATE_KEY_ENV_KEY = "SSH_PRIVATE_KEY"
 
-    ssh_private_key: Optional[str]
+    ssh_private_key: str | None
 
     def __str__(self) -> str:
         return f"Worker {self.worker_instance}"

--- a/src/lando/api/legacy/workers/landing_worker.py
+++ b/src/lando/api/legacy/workers/landing_worker.py
@@ -4,10 +4,6 @@ import configparser
 import logging
 import subprocess
 from pathlib import Path
-from typing import (
-    Optional,
-    Type,
-)
 
 import kombu
 from django.db import transaction
@@ -52,14 +48,14 @@ from lando.utils.tasks import phab_trigger_repo_update
 
 logger = logging.getLogger(__name__)
 
-COMMIT_CHECKS: list[Type[PatchCheck]] = [
+COMMIT_CHECKS: list[type[PatchCheck]] = [
     PreventSymlinksCheck,
     TryTaskConfigCheck,
     PreventNSPRNSSCheck,
     PreventSubmodulesCheck,
 ]
 
-STACK_CHECKS: list[Type[PatchCollectionCheck]] = [
+STACK_CHECKS: list[type[PatchCollectionCheck]] = [
     CommitMessagesCheck,
     # We don't include the WPT check here, as wptsyncbot cannot be the push user for a landing from Phabricator.
 ]
@@ -403,13 +399,13 @@ class LandingWorker(Worker):
         scm: AbstractSCM,
         bug_ids: list[str],
         changeset_titles: list[str],
-    ) -> Optional[str]:
+    ) -> str | None:
         """
         Determine and apply the repo's autoformatting rules.
 
         If no `.lando.ini` configuration can be found in the repo, autoformatting is skipped with a warning, but returns a success status.
 
-        Returns: Optional[str]
+        Returns: str | None
             None: no error
             str: error message
         """
@@ -452,10 +448,10 @@ class LandingWorker(Worker):
     def apply_autoformatting(
         self,
         scm: AbstractSCM,
-        landoini_config: Optional[configparser.ConfigParser],
+        landoini_config: configparser.ConfigParser | None,
         bug_ids: list[str],
         changeset_titles: list[str],
-    ) -> Optional[list[str]]:
+    ) -> list[str] | None:
         try:
             self.format_stack(landoini_config, scm.path)
         except AutoformattingException as exc:
@@ -551,7 +547,7 @@ class LandingWorker(Worker):
 
             raise exc
 
-    def mach_path(self, path: str) -> Optional[Path]:
+    def mach_path(self, path: str) -> Path | None:
         """Return the `Path` to `mach`, if it exists."""
         mach_path = Path(path) / "mach"
         if mach_path.exists():
@@ -559,7 +555,7 @@ class LandingWorker(Worker):
 
     def commit_autoformatting_changes(
         self, scm: AbstractSCM, stack_size: int, bug_ids: list[str]
-    ) -> Optional[list[str]]:
+    ) -> list[str] | None:
         """Call the SCM implementation to commit pending autoformatting changes.
 
         If the `stack_size` is 1, the tip commit will get amended. Otherwise, a new

--- a/src/lando/api/tests/test_landings.py
+++ b/src/lando/api/tests/test_landings.py
@@ -340,7 +340,7 @@ aDd oNe mOrE LiNe
 def test_integrated_execute_job(
     repo_mc,
     treestatusdouble,
-    mock_landing_worker_phab_repo_update,
+    mock_phab_trigger_repo_update_apply_async,
     create_patch_revision,
     make_landing_job,
     repo_type: str,
@@ -368,7 +368,7 @@ def test_integrated_execute_job(
     assert job.status == JobStatus.LANDED, job.error
     assert len(job.landed_commit_id) == 40
     assert (
-        mock_landing_worker_phab_repo_update.call_count == 1
+        mock_phab_trigger_repo_update_apply_async.call_count == 1
     ), "Successful landing should trigger Phab repo update."
 
     new_commit_count = Commit.objects.filter(repo=repo).count()
@@ -390,7 +390,7 @@ def test_integrated_execute_job(
 def test_integrated_execute_job_with_force_push(
     repo_mc,
     treestatusdouble,
-    mock_landing_worker_phab_repo_update,
+    mock_phab_trigger_repo_update_apply_async,
     create_patch_revision,
     make_landing_job,
     get_landing_worker,
@@ -434,7 +434,7 @@ def test_integrated_execute_job_with_force_push(
 def test_integrated_execute_job_with_bookmark(
     repo_mc,
     treestatusdouble,
-    mock_landing_worker_phab_repo_update,
+    mock_phab_trigger_repo_update_apply_async,
     create_patch_revision,
     make_landing_job,
     get_landing_worker,
@@ -601,7 +601,7 @@ def test_lose_push_race(
 def test_merge_conflict(
     repo_mc,
     treestatusdouble,
-    mock_landing_worker_phab_repo_update,
+    mock_phab_trigger_repo_update_apply_async,
     create_patch_revision,
     make_landing_job,
     caplog,
@@ -824,7 +824,7 @@ def test_failed_landing_job_notification(
 def test_format_patch_success_unchanged(
     repo_mc,
     treestatusdouble,
-    mock_landing_worker_phab_repo_update,
+    mock_phab_trigger_repo_update_apply_async,
     create_patch_revision,
     make_landing_job,
     normal_patch,
@@ -861,7 +861,7 @@ def test_format_patch_success_unchanged(
         job.status == JobStatus.LANDED
     ), "Successful landing should set `LANDED` status."
     assert (
-        mock_landing_worker_phab_repo_update.call_count == 1
+        mock_phab_trigger_repo_update_apply_async.call_count == 1
     ), "Successful landing should trigger Phab repo update."
     assert (
         job.formatted_replacements is None
@@ -879,7 +879,7 @@ def test_format_patch_success_unchanged(
 def test_format_single_success_changed(
     repo_mc,
     treestatusdouble,
-    mock_landing_worker_phab_repo_update,
+    mock_phab_trigger_repo_update_apply_async,
     create_patch_revision,
     make_landing_job,
     get_landing_worker,
@@ -927,7 +927,7 @@ def test_format_single_success_changed(
         job.status == JobStatus.LANDED
     ), "Successful landing should set `LANDED` status."
     assert (
-        mock_landing_worker_phab_repo_update.call_count == 1
+        mock_phab_trigger_repo_update_apply_async.call_count == 1
     ), "Successful landing should trigger Phab repo update."
 
     with scm.for_push(job.requester_email):
@@ -963,7 +963,7 @@ def test_format_single_success_changed(
 def test_format_stack_success_changed(
     repo_mc,
     treestatusdouble,
-    mock_landing_worker_phab_repo_update,
+    mock_phab_trigger_repo_update_apply_async,
     create_patch_revision,
     make_landing_job,
     get_landing_worker,
@@ -1001,7 +1001,7 @@ def test_format_stack_success_changed(
         job.status == JobStatus.LANDED
     ), "Successful landing should set `LANDED` status."
     assert (
-        mock_landing_worker_phab_repo_update.call_count == 1
+        mock_phab_trigger_repo_update_apply_async.call_count == 1
     ), "Successful landing should trigger Phab repo update."
 
     with scm.for_push(job.requester_email):
@@ -1097,7 +1097,7 @@ def test_format_patch_no_landoini(
     repo_mc,
     treestatusdouble,
     monkeypatch,
-    mock_landing_worker_phab_repo_update,
+    mock_phab_trigger_repo_update_apply_async,
     create_patch_revision,
     make_landing_job,
     get_landing_worker,
@@ -1137,7 +1137,7 @@ def test_format_patch_no_landoini(
         mock_notify.call_count == 0
     ), "Should not notify user of landing failure due to `.lando.ini` missing."
     assert (
-        mock_landing_worker_phab_repo_update.call_count == 1
+        mock_phab_trigger_repo_update_apply_async.call_count == 1
     ), "Successful landing should trigger Phab repo update."
 
 

--- a/src/lando/conftest.py
+++ b/src/lando/conftest.py
@@ -962,21 +962,10 @@ def commit_maps(git_repo):
 
 
 @pytest.fixture
-def mock_landing_worker_phab_repo_update(monkeypatch):
+def mock_phab_trigger_repo_update_apply_async(monkeypatch: pytest.MonkeyPatch):
     mock_trigger_update = mock.MagicMock()
     monkeypatch.setattr(
-        "lando.api.legacy.workers.landing_worker.LandingWorker.phab_trigger_repo_update",
-        mock_trigger_update,
-    )
-
-    return mock_trigger_update
-
-
-@pytest.fixture
-def mock_automation_worker_phab_repo_update(monkeypatch):
-    mock_trigger_update = mock.MagicMock()
-    monkeypatch.setattr(
-        "lando.api.legacy.workers.automation_worker.AutomationWorker.phab_trigger_repo_update",
+        "lando.utils.tasks.phab_trigger_repo_update.apply_async",
         mock_trigger_update,
     )
 

--- a/src/lando/headless_api/models/automation_job.py
+++ b/src/lando/headless_api/models/automation_job.py
@@ -68,7 +68,7 @@ class AutomationJob(BaseJob):
         return target_cset, push_target
 
     @property
-    def has_one_action(self) -> int:
+    def has_one_action(self) -> bool:
         return self.actions.count() == 1
 
 

--- a/src/lando/headless_api/tests/test_automation_api.py
+++ b/src/lando/headless_api/tests/test_automation_api.py
@@ -530,7 +530,7 @@ def test_automation_job_add_commit_success_hg(
     treestatusdouble,
     hg_automation_worker,
     repo_mc,
-    mock_automation_worker_phab_repo_update,
+    mock_phab_trigger_repo_update_apply_async,
     normal_patch,
     automation_job,
 ):
@@ -557,7 +557,7 @@ def test_automation_job_add_commit_success_hg(
 
     scm.push = mock.MagicMock()
 
-    assert hg_automation_worker.run_automation_job(job)
+    assert hg_automation_worker.run_job(job)
     assert scm.push.call_count == 1
     assert len(scm.push.call_args) == 2
     assert len(scm.push.call_args[0]) == 1
@@ -572,7 +572,7 @@ def test_automation_job_add_commit_success_git(
     treestatusdouble,
     git_automation_worker,
     repo_mc,
-    mock_automation_worker_phab_repo_update,
+    mock_phab_trigger_repo_update_apply_async,
     git_patch,
     automation_job,
 ):
@@ -604,7 +604,7 @@ def test_automation_job_add_commit_success_git(
 
     scm.push = mock.MagicMock()
 
-    assert git_automation_worker.run_automation_job(job)
+    assert git_automation_worker.run_job(job)
 
     assert job.status == JobStatus.LANDED, job.error
     assert len(job.landed_commit_id) == 40, "Landed commit ID should be a 40-char SHA."
@@ -620,7 +620,7 @@ def test_automation_job_add_commit_base64_success_git(
     treestatusdouble,
     git_automation_worker,
     repo_mc,
-    mock_automation_worker_phab_repo_update,
+    mock_phab_trigger_repo_update_apply_async,
     git_patch,
     automation_job,
 ):
@@ -649,7 +649,7 @@ def test_automation_job_add_commit_base64_success_git(
 
     scm.push = mock.MagicMock()
 
-    assert git_automation_worker.run_automation_job(job)
+    assert git_automation_worker.run_job(job)
     assert scm.push.call_count == 1
     assert len(scm.push.call_args) == 2
     assert len(scm.push.call_args[0]) == 1
@@ -665,7 +665,7 @@ def test_automation_job_add_commit_fail(
     repo_mc,
     treestatusdouble,
     hg_automation_worker,
-    mock_automation_worker_phab_repo_update,
+    mock_phab_trigger_repo_update_apply_async,
     automation_job,
 ):
     repo = repo_mc(SCM_TYPE_GIT)
@@ -689,7 +689,7 @@ def test_automation_job_add_commit_fail(
 
     scm.push = mock.MagicMock()
 
-    assert not hg_automation_worker.run_automation_job(job)
+    assert not hg_automation_worker.run_job(job)
     assert job.status == JobStatus.FAILED, "Automation job should fail."
     assert scm.push.call_count == 0
 
@@ -701,7 +701,7 @@ def test_automation_job_create_commit_success(
     repo_mc,
     treestatusdouble,
     get_automation_worker,
-    mock_automation_worker_phab_repo_update,
+    mock_phab_trigger_repo_update_apply_async,
     get_failing_check_diff,
     automation_job,
 ):
@@ -730,7 +730,7 @@ def test_automation_job_create_commit_success(
 
     scm.push = mock.MagicMock()
 
-    assert automation_worker.run_automation_job(job)
+    assert automation_worker.run_job(job)
     assert scm.push.call_count == 1
     assert len(scm.push.call_args) == 2
     assert len(scm.push.call_args[0]) == 1
@@ -755,7 +755,7 @@ def test_automation_job_create_commit_failed_check(
     repo_mc,
     treestatusdouble,
     get_automation_worker,
-    mock_automation_worker_phab_repo_update,
+    mock_phab_trigger_repo_update_apply_async,
     get_failing_check_action_reason: Callable,
     bad_action_type: str,
     hooks_enabled: bool,
@@ -786,9 +786,7 @@ def test_automation_job_create_commit_failed_check(
 
     scm.push = mock.MagicMock()
 
-    assert automation_worker.run_automation_job(
-        job
-    ), "Job indicated that it should be retried"
+    assert automation_worker.run_job(job), "Job indicated that it should be retried"
 
     if hooks_enabled:
         assert (
@@ -830,7 +828,7 @@ def test_automation_job_create_commit_failed_check_override(
     repo_mc,
     treestatusdouble,
     get_automation_worker,
-    mock_automation_worker_phab_repo_update,
+    mock_phab_trigger_repo_update_apply_async: mock.Mock,
     get_failing_check_action_reason: Callable,
     get_failing_check_diff,
     automation_job,
@@ -861,9 +859,7 @@ def test_automation_job_create_commit_failed_check_override(
 
     scm.push = mock.MagicMock()
 
-    assert automation_worker.run_automation_job(
-        job
-    ), "Job indicated that it should be retried"
+    assert automation_worker.run_job(job), "Job indicated that it should be retried"
     assert job.status == JobStatus.LANDED, f"Job failed despite overrides: {job.error}"
 
 
@@ -872,7 +868,7 @@ def test_automation_job_create_commit_failed_check_unchecked(
     repo_mc,
     treestatusdouble,
     get_automation_worker,
-    mock_automation_worker_phab_repo_update,
+    mock_phab_trigger_repo_update_apply_async: mock.Mock,
     get_failing_check_action_reason: Callable,
     get_failing_check_diff,
     automation_job,
@@ -905,7 +901,7 @@ def test_automation_job_create_commit_failed_check_unchecked(
     monkeypatch.setattr(
         automation_worker, "run_automation_checks", mock_run_automation_checks
     )
-    automation_worker.run_automation_job(job)
+    automation_worker.run_job(job)
     assert mock_run_automation_checks.call_count == 1
 
     # Create the same job with an invalid action and a commit with release override.
@@ -919,7 +915,7 @@ def test_automation_job_create_commit_failed_check_unchecked(
     monkeypatch.setattr(
         automation_worker, "run_automation_checks", mock_run_automation_checks
     )
-    automation_worker.run_automation_job(job)
+    automation_worker.run_job(job)
     assert mock_run_automation_checks.call_count == 0
 
 
@@ -959,7 +955,7 @@ def test_automation_job_create_commit_patch_conflict(
 
     monkeypatch.setattr(repo.scm, "apply_patch", raise_conflict)
 
-    assert not automation_worker.run_automation_job(job)
+    assert not automation_worker.run_job(job)
 
     assert "Merge conflict while creating commit" in job.error
     job.refresh_from_db()
@@ -1020,7 +1016,7 @@ def test_automation_job_merge_onto_success_git(
 
     git_automation_worker.worker_instance.applicable_repos.add(repo)
 
-    assert git_automation_worker.run_automation_job(job)
+    assert git_automation_worker.run_job(job)
     assert job.status == JobStatus.LANDED, f"Job unexpectedly failed: {job.error}"
     assert scm.push.called
     assert len(job.landed_commit_id) == 40
@@ -1073,7 +1069,7 @@ def test_automation_job_merge_onto_fast_forward_git(
     monkeypatch.setattr(
         git_automation_worker, "run_automation_checks", mock_run_automation_checks
     )
-    assert git_automation_worker.run_automation_job(job)
+    assert git_automation_worker.run_job(job)
     assert mock_run_automation_checks.call_count == 0
     assert job.status == JobStatus.LANDED
 
@@ -1165,7 +1161,7 @@ def test_automation_job_merge_onto_success_hg(
 
     hg_automation_worker.worker_instance.applicable_repos.add(repo)
 
-    assert hg_automation_worker.run_automation_job(job)
+    assert hg_automation_worker.run_job(job)
     assert job.status == JobStatus.LANDED
     assert scm.push.called
     assert len(job.landed_commit_id) == 40
@@ -1200,9 +1196,7 @@ def test_automation_job_merge_onto_fail(
     automation_worker = get_automation_worker(scm_type)
     automation_worker.worker_instance.applicable_repos.add(repo)
 
-    assert not automation_worker.run_automation_job(
-        job
-    ), f"Job should fail for SCM: {scm_type}"
+    assert not automation_worker.run_job(job), f"Job should fail for SCM: {scm_type}"
     assert job.status == JobStatus.FAILED
     assert "Aborting, could not perform `merge-onto`" in job.error
 
@@ -1243,7 +1237,7 @@ def test_automation_job_tag_success_git_tip_commit(
     automation_worker = get_automation_worker(SCM_TYPE_GIT)
     automation_worker.worker_instance.applicable_repos.add(repo)
 
-    assert automation_worker.run_automation_job(job)
+    assert automation_worker.run_job(job)
     assert job.status == JobStatus.LANDED
 
     # Tag should be on the most recent commit.
@@ -1375,7 +1369,7 @@ def test_automation_job_tag_success_git_new_commit(
     monkeypatch.setattr(
         automation_worker, "run_automation_checks", mock_run_automation_checks
     )
-    assert automation_worker.run_automation_job(job)
+    assert automation_worker.run_job(job)
     assert mock_run_automation_checks.call_count == 1
     assert job.status == JobStatus.LANDED
 
@@ -1428,7 +1422,7 @@ def test_automation_job_tag_failure_git(
     automation_worker = get_automation_worker(SCM_TYPE_GIT)
     automation_worker.worker_instance.applicable_repos.add(repo)
 
-    assert not automation_worker.run_automation_job(job)
+    assert not automation_worker.run_job(job)
     job.refresh_from_db()
     assert job.status == JobStatus.FAILED
     assert "Aborting, could not perform `tag`, action #1" in job.error
@@ -1476,7 +1470,7 @@ def test_automation_job_tag_success_hg(
     automation_worker = get_automation_worker(SCM_TYPE_HG)
     automation_worker.worker_instance.applicable_repos.add(repo)
 
-    assert automation_worker.run_automation_job(job)
+    assert automation_worker.run_job(job)
     assert job.status == JobStatus.LANDED, job.error
 
     # Verify the created commit is the one with the tag.
@@ -1565,7 +1559,7 @@ def test_create_and_push_to_new_relbranch(
     job = AutomationJob.objects.get(id=job_id)
 
     git_automation_worker.worker_instance.applicable_repos.add(repo)
-    assert git_automation_worker.run_automation_job(job)
+    assert git_automation_worker.run_job(job)
 
     assert job.status == JobStatus.LANDED
     assert job.landed_commit_id is not None
@@ -1695,7 +1689,7 @@ def test_push_to_existing_relbranch(
     job = AutomationJob.objects.get(id=job_id)
 
     git_automation_worker.worker_instance.applicable_repos.add(repo)
-    assert git_automation_worker.run_automation_job(job)
+    assert git_automation_worker.run_job(job)
 
     assert job.status == JobStatus.LANDED
     assert job.landed_commit_id is not None


### PR DESCRIPTION
* explicit base properties
* abstract `type` property
* add abstract `job_type` property
* factor `__init__()` in
* factor `loop()` in
* make `run_job()` part of the interface, and rename
  `run_automation_job()`
* add `call_task()` for generic async calls