### PR TITLE
uplift: add Phabricator API key warning to assessment edit modal (Bug 1988547)

### DIFF
--- a/src/lando/ui/jinja2/stack/partials/uplift-form.html
+++ b/src/lando/ui/jinja2/stack/partials/uplift-form.html
@@ -14,7 +14,9 @@
       <section class="modal-card-body">
         {{ uplift_request_form.source_revision_id }}
 
-        {% include "stack/partials/uplift-phab-api-key-warning.html" %}
+        {% if not user_has_phabricator_token %}
+            {% include "stack/partials/uplift-phab-api-key-warning.html" %}
+        {% endif %}
 
         {% if uplift_stack_too_large %}
           <article class="message is-danger">

--- a/src/lando/ui/jinja2/stack/partials/uplift-phab-api-key-warning.html
+++ b/src/lando/ui/jinja2/stack/partials/uplift-phab-api-key-warning.html
@@ -1,4 +1,3 @@
-{% if not user_has_phabricator_token %}
 <article class="message is-danger">
   <div class="message-header">
     <p>Phabricator API Key Required</p>
@@ -8,4 +7,3 @@
     Click on your username in the navbar above to open your user settings.
   </div>
 </article>
-{% endif %}

--- a/src/lando/ui/jinja2/stack/partials/uplift-section.html
+++ b/src/lando/ui/jinja2/stack/partials/uplift-section.html
@@ -39,7 +39,9 @@ future.
             <section class="modal-card-body">
                 {{ csrf_input }}
 
-                {% include "stack/partials/uplift-phab-api-key-warning.html" %}
+                {% if not user_has_phabricator_token %}
+                    {% include "stack/partials/uplift-phab-api-key-warning.html" %}
+                {% endif %}
 
                 {# Revision ID is a hidden field for now. #}
                 {{ uplift_assessment_form.revision_id }}


### PR DESCRIPTION
Move the "Phabricator API Key Required" warning into a partial
and display in both the "Request Uplift" and "Edit Assessment"
modals. Also disable the submit button on the "Edit Assessment"
modal when the API key is missing.
