### PR TITLE
CommitMap: use correct fromchange argument to json-pushes (bug 1988682)

### DIFF
--- a/src/lando/main/models/commit_map.py
+++ b/src/lando/main/models/commit_map.py
@@ -105,7 +105,7 @@ class CommitMap(BaseModel):
         """Find the last stored commit hash and query the pushlog."""
         params = {}
         try:
-            params["fromchangeset"] = cls.find_last_hg_node(git_repo_name)
+            params["fromchange"] = cls.find_last_hg_node(git_repo_name)
         except cls.DoesNotExist as exc:
             raise cls.DoesNotExist(
                 f"No commit map entry found for {git_repo_name}, use `lando process_git_hg_mapping_file` to bootstrap"

--- a/src/lando/main/models/commit_map.py
+++ b/src/lando/main/models/commit_map.py
@@ -6,7 +6,6 @@ import sentry_sdk
 from django.db import models
 
 from lando.main.models.base import BaseModel
-from lando.main.models.repo import Repo
 from lando.main.scm.consts import SCM_TYPE_GIT, SCM_TYPE_HG
 
 logger = logging.getLogger(__name__)
@@ -57,7 +56,7 @@ class CommitMap(BaseModel):
         return cls.objects.filter(git_repo_name=git_repo_name).latest("created_at")
 
     @classmethod
-    def find_last_hg_node(cls, git_repo_name: Repo) -> str:
+    def find_last_hg_node(cls, git_repo_name: str) -> str:
         """Return hg hash of last CommitMap object for given repo."""
         return cls._find_last_node(git_repo_name).hg_hash
 
@@ -104,11 +103,15 @@ class CommitMap(BaseModel):
     @classmethod
     def catch_up(cls, git_repo_name: str):
         """Find the last stored commit hash and query the pushlog."""
-        commit_hash = cls.find_last_hg_node(git_repo_name)
-        cls.fetch_push_data(
-            git_repo_name=git_repo_name,
-            fromchangeset=commit_hash,
-        )
+        params = {}
+        try:
+            params["fromchangeset"] = cls.find_last_hg_node(git_repo_name)
+        except cls.DoesNotExist as exc:
+            raise cls.DoesNotExist(
+                f"No commit map entry found for {git_repo_name}, use `lando process_git_hg_mapping_file` to bootstrap"
+            ) from exc
+
+        cls.fetch_push_data(git_repo_name=git_repo_name, **params)
 
     @classmethod
     def fetch_push_data(cls, git_repo_name: str, **kwargs) -> dict:

--- a/src/lando/main/tests/test_models.py
+++ b/src/lando/main/tests/test_models.py
@@ -303,7 +303,7 @@ def test__models__CommitMap__catch_up(commit_maps, monkeypatch):
     assert mock_find_last_hg_node.call_args[0] == ("git_repo",)
     assert mock_fetch_push_data.call_args[1] == {
         "git_repo_name": "git_repo",
-        "fromchangeset": mock_find_last_hg_node.return_value,
+        "fromchange": mock_find_last_hg_node.return_value,
     }
 
 
@@ -314,12 +314,12 @@ def test__models__CommitMap__fetch_push_data(commit_maps, monkeypatch):
     mock_requests_get = MagicMock()
     mock_requests_get(
         "https://hg.mozilla.org/git_repo/json-pushes",
-        params={"fromchangeset": last_hg_node},
+        params={"fromchange": last_hg_node},
     ).json.return_value = {
         "some_push": {"changesets": ["1" * 40], "git_changesets": ["2" * 40]}
     }
     monkeypatch.setattr("lando.main.models.commit_map.requests.get", mock_requests_get)
-    CommitMap.fetch_push_data("git_repo", fromchangeset=last_hg_node)
+    CommitMap.fetch_push_data("git_repo", fromchange=last_hg_node)
     assert CommitMap.objects.all().count() == previous_commit_map_count + 1
     assert CommitMap.find_last_hg_node("git_repo") == "1" * 40
 
@@ -331,13 +331,13 @@ def test__models__CommitMap__fetch_push_data_invalid_response(commit_maps, monke
     mock_requests_get = MagicMock()
     mock_requests_get(
         "https://hg.mozilla.org/git_repo/json-pushes",
-        params={"fromchangeset": last_hg_node},
+        params={"fromchange": last_hg_node},
     ).json.return_value = {
         "some_push": {"changesets": ["1" * 40, "2" * 40], "git_changesets": ["3" * 40]}
     }
     monkeypatch.setattr("lando.main.models.commit_map.requests.get", mock_requests_get)
     with pytest.raises(ValueError) as e:
-        CommitMap.fetch_push_data("git_repo", fromchangeset=last_hg_node)
+        CommitMap.fetch_push_data("git_repo", fromchange=last_hg_node)
     assert e.value.args == (
         "Number of hg changesets does not match number of git changesets: 2 vs 1",
     )


### PR DESCRIPTION
We were using `fromchangeset`, but the `json-pushes` command expects `fromchange`.

Aditionally, when catching up, some older commits in m-u may not have a `git_commit` recorded, or may not even be present in mf/f. We skip over those with a warning.

Finally, warn if no commits are known, as there are multiple cases where a `CommitMap.DoesNotExist` can be raised. This allows to differentiate them at runtime, and offers a way to fix.