### PR TITLE
testing: allow `/repos` dir to exist (Bug 1989303)

### DIFF
--- a/src/lando/conftest.py
+++ b/src/lando/conftest.py
@@ -537,7 +537,7 @@ def git_repo_mc(
     push_target: str = "",
 ) -> Repo:
     repos_dir = tmp_path / "repos"
-    repos_dir.mkdir()
+    repos_dir.mkdir(exist_ok=True)
 
     params = {
         "name": name or "mozilla-central-git",


### PR DESCRIPTION
When using `repo_mc` to create two test repos in one
test, creating the second repo fails because we call
`mkdir` when the `/repos` dir already exists. Add
`exists_ok=True` so multiple repos can be created in
one test.
