### PR TITLE
uplift: query Lando `Repo` objects instead of Phab repo endpoint (Bug 1989305)

### DIFF
--- a/src/lando/ui/legacy/forms.py
+++ b/src/lando/ui/legacy/forms.py
@@ -1,7 +1,6 @@
 from django import forms
 from django.forms.widgets import RadioSelect
 
-from lando.api.legacy.uplift import get_uplift_repositories
 from lando.main.models import Repo
 from lando.main.models.uplift import (
     UpliftAssessment,
@@ -85,8 +84,10 @@ class UpliftRequestForm(UpliftAssessmentForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        uplift_repos = get_uplift_repositories()
-        self.fields["repository"].choices = [(repo, repo) for repo in uplift_repos]
+        uplift_repos = Repo.objects.filter(approval_required=True).all()
+        self.fields["repository"].choices = [
+            (repo.name, repo.name) for repo in uplift_repos
+        ]
 
     def clean_repository(self) -> str:
         repo_short_name = self.cleaned_data["repository"]


### PR DESCRIPTION
Switch the `UpliftRequestForm` to query Lando's local `Repo`s
with the `approval_required=True` flag to gather the list of
valid uplift repositories. This removes an API call to Phabricator
to gather information which Lando already contains locally.
