### PR TITLE
uplifts: warn that "Request Uplift" creates new revisions (Bug 1990937)

### DIFF
--- a/src/lando/ui/jinja2/stack/partials/uplift-form.html
+++ b/src/lando/ui/jinja2/stack/partials/uplift-form.html
@@ -18,6 +18,19 @@
             {% include "stack/partials/uplift-phab-api-key-warning.html" %}
         {% endif %}
 
+        {% if revision_repo and revision_repo.approval_required %}
+        <article class="message is-warning">
+          <div class="message-header">
+            <p>Action Creates New Phabricator Revisions</p>
+          </div>
+          <div class="message-body">
+            Using the Request Uplift button will generate new Phabricator uplift
+            revisions. If you only want to complete the uplift assessment form for
+            this revision, please use the "Edit Uplift Assessment" button instead.
+          </div>
+        </article>
+        {% endif %}
+
         {% if uplift_stack_too_large %}
           <article class="message is-danger">
             <div class="message-header">

--- a/src/lando/ui/jinja2/stack/partials/uplift-section.html
+++ b/src/lando/ui/jinja2/stack/partials/uplift-section.html
@@ -15,7 +15,7 @@ future.
                         <i class="fa fa-pencil-square-o" aria-hidden="true"></i>
                     </span>
                     <span>
-                    Uplift Assessment
+                    Edit Uplift Assessment
                     </span>
                 </button>
             </div>


### PR DESCRIPTION
When using the "Request Uplift" button from an existing uplift revision
in Lando, add a warning indicating that the form will generate new
Phabricator revisions. This helps avoid confusion when a developer
means to fill out the assessment form, but clicks the "Request Uplift"
button instead.

Also add "Edit" to the button text so it is clearer that the button
is used to edit the form.
