### PR TITLE
treestatus: don't raise from is_open on communication error (bug 1992190)

### DIFF
--- a/src/lando/api/legacy/treestatus.py
+++ b/src/lando/api/legacy/treestatus.py
@@ -36,6 +36,9 @@ class TreeStatus:
 
             # We assume missing trees are open.
             return True
+        except TreeStatusCommunicationException:
+            # Assume closed, and let the caller try again later
+            return False
 
         try:
             return resp["result"]["status"] in TreeStatus.OPEN_STATUSES

--- a/src/lando/api/tests/test_treestatus.py
+++ b/src/lando/api/tests/test_treestatus.py
@@ -108,3 +108,14 @@ def test_is_open_for_approval_required_tree(treestatusdouble):
     ts = treestatusdouble.get_treestatus_client()
     treestatusdouble.set_tree("mozilla-central", status="approval required")
     assert ts.is_open("mozilla-central")
+
+
+def test_is_open_assumes_false_on_error(treestatusdouble, monkeypatch):
+    ts = treestatusdouble.get_treestatus_client()
+
+    def fake_get_trees(*args, **kwargs):
+        raise TreeStatusCommunicationException()
+
+    monkeypatch.setattr(ts, "get_trees", fake_get_trees)
+
+    assert not ts.is_open("mozilla-central")


### PR DESCRIPTION
Let is_open return false on TreeStatusCommunicationException.  That lets the landing worker defer the job instead of failing with an unhandled exception.