### PR TITLE
phab: fix operator precedence logic in `get_phabricator_client` (Bug 2030455)

### DIFF
--- a/src/lando/main/management/commands/backfill_phids.py
+++ b/src/lando/main/management/commands/backfill_phids.py
@@ -1,0 +1,93 @@
+import argparse
+import logging
+
+from django.conf import settings
+from django.core.management.base import BaseCommand
+
+from lando.main.models.profile import Profile
+from lando.utils.phabricator import PhabricatorClient
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    help = "Back-fill `phabricator_phid` for profiles that have an API key but no PHID."
+    name = "backfill_phids"
+
+    def add_arguments(self, parser: argparse.ArgumentParser):
+        parser.add_argument(
+            "--execute",
+            action="store_true",
+            help="Actually make changes. Without this flag, only logs what would be done.",
+        )
+
+    def handle(self, *args, **options):
+        execute = options["execute"]
+
+        profiles = Profile.objects.filter(
+            phabricator_phid__isnull=True,
+        ).exclude(
+            encrypted_phabricator_api_key=b"",
+        )
+
+        self.stdout.write(
+            f"Found {profiles.count()} profiles with an API key but no PHID."
+        )
+
+        for profile in profiles:
+            api_key = profile.phabricator_api_key
+            if not api_key:
+                logger.debug(
+                    "Profile %s has an empty API key after decryption, skipping.",
+                    profile.pk,
+                )
+                continue
+
+            phab = PhabricatorClient(settings.PHABRICATOR_URL, api_key)
+            whoami = phab.verify_api_token()
+
+            if not whoami:
+                self.stdout.write(
+                    self.style.WARNING(
+                        f"Profile {profile.pk} (user={profile.user}): "
+                        f"API key is invalid, skipping."
+                    )
+                )
+                continue
+
+            phid = whoami["phid"]
+            username = whoami.get("userName", "unknown")
+
+            if not execute:
+                self.stdout.write(
+                    f"[DRY RUN] Profile {profile.pk} (user={profile.user}): "
+                    f"would set PHID to `{phid}` (`{username}`)."
+                )
+                continue
+
+            existing = (
+                Profile.objects.filter(
+                    phabricator_phid=phid,
+                )
+                .exclude(pk=profile.pk)
+                .first()
+            )
+
+            if existing:
+                self.stdout.write(
+                    self.style.WARNING(
+                        f"Profile {profile.pk} (user={profile.user}): "
+                        f"PHID `{phid}` (`{username}`) is already claimed by "
+                        f"profile {existing.pk} (user={existing.user}), skipping."
+                    )
+                )
+                continue
+
+            profile.phabricator_phid = phid
+            profile.save(update_fields=["phabricator_phid"])
+            self.stdout.write(
+                self.style.SUCCESS(
+                    f"Profile {profile.pk} (user={profile.user}): "
+                    f"set PHID to `{phid}` (`{username}`)."
+                )
+            )

--- a/src/lando/utils/phabricator.py
+++ b/src/lando/utils/phabricator.py
@@ -386,13 +386,10 @@ def get_phabricator_client(
     privileged: Optional[bool] = False, api_key: Optional[str] = None
 ) -> PhabricatorClient:
     """Return an initialized PhabricatorClient object with relevant API key."""
-    api_key = (
-        api_key or settings.PHABRICATOR_ADMIN_API_KEY
-        if privileged
-        else settings.PHABRICATOR_UNPRIVILEGED_API_KEY
-    )
-    phab = PhabricatorClient(
-        settings.PHABRICATOR_URL,
-        api_key,
-    )
-    return phab
+    if api_key is None:
+        api_key = (
+            settings.PHABRICATOR_ADMIN_API_KEY
+            if privileged
+            else settings.PHABRICATOR_UNPRIVILEGED_API_KEY
+        )
+    return PhabricatorClient(settings.PHABRICATOR_URL, api_key)

--- a/src/lando/utils/tests/test_phabricator.py
+++ b/src/lando/utils/tests/test_phabricator.py
@@ -1,0 +1,31 @@
+import pytest
+from django.conf import settings
+
+from lando.utils.phabricator import get_phabricator_client
+
+USER_KEY = "api-userprovidedkey00000000000000"
+
+
+@pytest.mark.parametrize(
+    "privileged, api_key, expected_token",
+    (
+        (False, USER_KEY, USER_KEY),
+        (True, USER_KEY, USER_KEY),
+        (False, None, settings.PHABRICATOR_UNPRIVILEGED_API_KEY),
+        (True, None, settings.PHABRICATOR_ADMIN_API_KEY),
+    ),
+    ids=(
+        "unprivileged-with-explicit-key",
+        "privileged-with-explicit-key",
+        "unprivileged-fallback",
+        "privileged-fallback",
+    ),
+)
+def test_get_phabricator_client_api_key_selection(privileged, api_key, expected_token):
+    """The client should use the provided `api_key` when given, and fall back
+    to the appropriate system key otherwise."""
+    client = get_phabricator_client(privileged=privileged, api_key=api_key)
+    assert client.api_token == expected_token, (
+        f"`get_phabricator_client(privileged={privileged}, api_key={api_key!r})` "
+        f"should produce a client with `api_token` `{expected_token!r}`."
+    )


### PR DESCRIPTION
Fix the operator precedence logic in `get_phabricator_client`
so we only consider the app-wide Phab keys when an `api_key`
is not passed. Add a test that fails before the fix is
applied to confirm the behaviour and fix.

Add a `backfill_phids` management command which populates
the PHID field on all existing Phabricator API keys to resolve
this issue for existing profiles.
