### PR TITLE
settings: set `access-control-allow-origin: *` header (bug 2030883)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "datadog",
     "django ~= 6.0",
     "django-auditlog",
+    "django-cors-headers",
     "django-ninja",
     "django-storages[google]",
     "django_compressor",

--- a/requirements.txt
+++ b/requirements.txt
@@ -155,7 +155,9 @@ anyio==4.12.1 \
 asgiref==3.11.1 \
     --hash=sha256:5f184dc43b7e763efe848065441eac62229c9f7b0475f41f80e207a114eda4ce \
     --hash=sha256:e8667a091e69529631969fd45dc268fa79b99c92c5fcdda727757e52146ec133
-    # via django
+    # via
+    #   django
+    #   django-cors-headers
 attrs==25.4.0 \
     --hash=sha256:16d5969b87f0859ef33a48b35d55ac1be6e42ae49d5e853b597db70c35c57e11 \
     --hash=sha256:adcf7e2a1fb3b36ac48d97835bb6d8ade15b8dcce26aba8bf1d14847b57a3373
@@ -868,6 +870,7 @@ django==6.0.4 \
     #   django-appconf
     #   django-auditlog
     #   django-compressor
+    #   django-cors-headers
     #   django-ninja
     #   django-storages
     #   lando (pyproject.toml)
@@ -883,6 +886,10 @@ django-auditlog==3.4.1 \
 django-compressor==4.6.0 \
     --hash=sha256:6e7b21020a0d86272c5e37000c33accc4ebeb77394a3dd86d775a09aae7aade4 \
     --hash=sha256:c7478feab98f3368780591f9ee28a433350f5277dd28811f7f710f5bc6dff3c0
+    # via lando (pyproject.toml)
+django-cors-headers==4.9.0 \
+    --hash=sha256:15c7f20727f90044dcee2216a9fd7303741a864865f0c3657e28b7056f61b449 \
+    --hash=sha256:fe5d7cb59fdc2c8c646ce84b727ac2bca8912a247e6e68e1fb507372178e59e8
     # via lando (pyproject.toml)
 django-ninja==1.6.0 \
     --hash=sha256:44c6e3f5f1b929cf51f645004715b36326ea32fddf1a94026c4917de8d230135 \
@@ -2625,9 +2632,7 @@ rs-parsepatch==0.4.6 \
 rsa==4.9.1 \
     --hash=sha256:68635866661c6836b8d39430f97a996acbd61bfa49406748ea243539fe239762 \
     --hash=sha256:e7bdbfdb5497da4c07dfd35530e1a902659db6ff241e39d9953cad06ebd0ae75
-    # via
-    #   google-auth
-    #   python-jose
+    # via python-jose
 ruamel-yaml==0.17.21 \
     --hash=sha256:742b35d3d665023981bd6d16b3d24248ce5df75fdb4e2924e93a05c1f8b61ca7 \
     --hash=sha256:8b7ce697a2f212752a35c1ac414471dc16c424c9573be4926b56ff3f5d23b7af

--- a/src/lando/main/tests/test_models.py
+++ b/src/lando/main/tests/test_models.py
@@ -87,14 +87,18 @@ def test__models__Repo__scm_not_calculated_when_preset(
         ("/invalid_path", ValidationError),
     ],
 )
-def test__models__Repo__system_path_validator(path, expected_exception):
+def test__models__Repo__system_path_validator(
+    request: pytest.FixtureRequest, path: str, expected_exception: Exception | None
+):
+
     repo = Repo(
         name="name",
         url="http://example.com",
         required_permission="required_permission",
         system_path=path,
     )
-    if expected_exception:
+
+    if expected_exception is not None:
         with pytest.raises(expected_exception):
             repo.clean_fields()
     else:

--- a/src/lando/main/tests/test_models.py
+++ b/src/lando/main/tests/test_models.py
@@ -88,7 +88,7 @@ def test__models__Repo__scm_not_calculated_when_preset(
     ],
 )
 def test__models__Repo__system_path_validator(
-    request: pytest.FixtureRequest, path: str, expected_exception: Exception | None
+    path: str, expected_exception: Exception | None
 ):
 
     repo = Repo(

--- a/src/lando/settings.py
+++ b/src/lando/settings.py
@@ -59,6 +59,11 @@ SECURE_SSL_REDIRECT = False
 SESSION_COOKIE_SECURE = True
 CSRF_COOKIE_SECURE = True
 
+# Configure the django-cors-headers middleware.
+CORS_ALLOW_ALL_ORIGINS = True
+# Only set the CORS header for those paths.
+CORS_URLS_REGEX = r"^(/landing_jobs)"
+
 # Set the default upload memory size to a large value, to support large uploads from
 # lando-cli.
 DATA_UPLOAD_MAX_MEMORY_SIZE = int(os.getenv("DATA_UPLOAD_MAX_MEMORY_SIZE", "524288000"))
@@ -87,12 +92,14 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.staticfiles",
     "compressor",
+    "corsheaders",
     "mozilla_django_oidc",
     "ninja",
     "auditlog",
 ]
 
 MIDDLEWARE = [
+    "corsheaders.middleware.CorsMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",

--- a/src/lando/tests/test_middlewares.py
+++ b/src/lando/tests/test_middlewares.py
@@ -29,7 +29,7 @@ def test_cors_acao_header(
         ), f"Missing ACAO header for request from '{origin}' to '{path}'"
         assert (
             resp.headers["access-control-allow-origin"] == "*"
-        ), f"Unexpected ACAO header value {resp.headers["access-control-allow-origin"]} for requesst from '{origin}' to '{path}'"
+        ), f"Unexpected ACAO header value {resp.headers["access-control-allow-origin"]} for request from '{origin}' to '{path}'"
     else:
         assert (
             "access-control-allow-origin" not in resp.headers

--- a/src/lando/tests/test_middlewares.py
+++ b/src/lando/tests/test_middlewares.py
@@ -18,7 +18,7 @@ def test_cors_acao_header(
 ):
 
     headers = {}
-    if origin:
+    if origin is not None:
         headers.update({"origin": origin})
 
     resp = client.get(path, headers=headers)

--- a/src/lando/tests/test_middlewares.py
+++ b/src/lando/tests/test_middlewares.py
@@ -1,0 +1,36 @@
+import pytest
+from django.test.client import Client
+
+
+@pytest.mark.parametrize(
+    "origin,path,expected_present",
+    (
+        ("", "/", False),
+        ("", "/landing_jobs/1", False),
+        ("treeherder", "/landing_jobs/1", True),
+        ("", "/api/1", False),
+        ("treeherder", "/api/1", False),
+    ),
+)
+@pytest.mark.django_db
+def test_cors_acao_header(
+    client: Client, origin: str, path: str, expected_present: bool
+):
+
+    headers = {}
+    if origin:
+        headers.update({"origin": origin})
+
+    resp = client.get(path, headers=headers)
+
+    if expected_present:
+        assert (
+            "access-control-allow-origin" in resp.headers
+        ), f"Missing ACAO header for request from '{origin}' to '{path}'"
+        assert (
+            resp.headers["access-control-allow-origin"] == "*"
+        ), f"Unexpected ACAO header value {resp.headers["access-control-allow-origin"]} for requesst from '{origin}' to '{path}'"
+    else:
+        assert (
+            "access-control-allow-origin" not in resp.headers
+        ), f"Unexpected ACAO header present for requesst from '{origin}' to '{path}'"

--- a/src/lando/tests/test_middlewares.py
+++ b/src/lando/tests/test_middlewares.py
@@ -33,4 +33,4 @@ def test_cors_acao_header(
     else:
         assert (
             "access-control-allow-origin" not in resp.headers
-        ), f"Unexpected ACAO header present for requesst from '{origin}' to '{path}'"
+        ), f"Unexpected ACAO header present for request from '{origin}' to '{path}'"


### PR DESCRIPTION
TreeHerder needs to be allowed to make requests to the `/landing_jobs/<job_id>` JSON endpoint to determine the landed Hg commit_id for a given job.

 * deps: add django-cors-headers
 * settings: set `access-control-allow-origin: *` header
 * test: add middlewares test for ACAO header
