### PR TITLE
uplifts: allow uplift requests before landing on autoland (Bug 2030756)

### DIFF
--- a/src/lando/api/legacy/api/transplants.py
+++ b/src/lando/api/legacy/api/transplants.py
@@ -1,6 +1,5 @@
 import logging
 import urllib.parse
-from datetime import datetime
 from typing import Any
 
 import kombu
@@ -25,11 +24,11 @@ from lando.api.legacy.reviews import (
     reviewers_for_commit_message,
 )
 from lando.api.legacy.revisions import (
+    fetch_raw_diff_and_save,
     find_title_and_summary_for_landing,
     gather_involved_phids,
     get_bugzilla_bug,
     revision_is_secure,
-    select_diff_author,
 )
 from lando.api.legacy.stacks import (
     RevisionStack,
@@ -52,7 +51,6 @@ from lando.main.models import (
     JobStatus,
     LandingJob,
     Repo,
-    Revision,
     add_revisions_to_job,
 )
 from lando.main.support import LegacyAPIException
@@ -298,35 +296,15 @@ def post(phab: PhabricatorClient, user: User, data: dict) -> tuple[dict[str, int
             ),
             flags,
         )[1]
-        author_name, author_email = select_diff_author(diff)
-        timestamp = int(datetime.now().timestamp())
-
-        # Construct the patch that will be transplanted.
-        revision_id = revision["id"]
-        diff_id = diff["id"]
-
-        lando_revision = Revision.get_from_revision_id(revision_id)
-        if not lando_revision:
-            lando_revision = Revision(revision_id=revision_id)
-
-        lando_revision.diff_id = diff_id
-        lando_revision.save()
+        lando_revision = fetch_raw_diff_and_save(
+            phab, revision["id"], diff, commit_message
+        )
 
         revision_reviewers[lando_revision.id] = get_approved_by_ids(
             phab,
             PhabricatorClient.expect(revision, "attachments", "reviewers", "reviewers"),
         )
 
-        patch_data = {
-            "author_name": author_name,
-            "author_email": author_email,
-            "commit_message": commit_message,
-            "timestamp": timestamp,
-        }
-
-        raw_diff = phab.call_conduit("differential.getrawdiff", diffID=diff["id"])
-        lando_revision.set_patch(raw_diff, patch_data)
-        lando_revision.save()
         lando_revisions.append(lando_revision)
 
     ldap_username = user.email

--- a/src/lando/api/legacy/revisions.py
+++ b/src/lando/api/legacy/revisions.py
@@ -1,11 +1,19 @@
 import logging
 from collections import Counter
+from datetime import datetime
 from typing import (
     Any,
     NamedTuple,
     Optional,
 )
 
+from django.db import transaction
+
+from lando.api.legacy.stacks import (
+    get_diffs_by_phid,
+    get_revisions_by_id,
+)
+from lando.main.models import Revision
 from lando.utils.phabricator import (
     PhabricatorClient,
     PhabricatorRevisionStatus,
@@ -239,3 +247,124 @@ def find_title_and_summary_for_landing(
         summary=PhabricatorClient.expect(revision, "fields", "summary"),
         sanitized=False,
     )
+
+
+def fetch_raw_diff_and_save(
+    phab: PhabricatorClient,
+    revision_id: int,
+    diff: dict,
+    commit_message: str,
+) -> Revision:
+    """Fetch the raw diff from Phabricator and save a `Revision` record.
+
+    This is the shared core for building `Revision` objects from Phabricator
+    data, used by both the regular landing flow and the uplift request flow.
+
+    Args:
+        phab: A PhabricatorClient instance.
+        revision_id: The integer revision ID (e.g. 123 for D123).
+        diff: A Phabricator diff dict with the `commits` attachment.
+        commit_message: The full commit message to embed in the patch.
+    """
+    diff_id = PhabricatorClient.expect(diff, "id")
+    author_name, author_email = select_diff_author(diff)
+
+    logger.debug("Fetching raw diff for D%s (diff %s).", revision_id, diff_id)
+    raw_diff = phab.call_conduit("differential.getrawdiff", diffID=diff_id)
+
+    patch_data = {
+        "author_name": author_name or "",
+        "author_email": author_email or "",
+        "commit_message": commit_message,
+        "timestamp": str(int(datetime.now().timestamp())),
+    }
+
+    with transaction.atomic():
+        revision, created = Revision.objects.update_or_create(
+            revision_id=revision_id,
+            defaults={"diff_id": diff_id},
+        )
+        revision.set_patch(raw_diff, patch_data)
+        revision.save()
+
+    logger.debug("Saved Revision D%s with diff %s.", revision_id, diff_id)
+    return revision
+
+
+def ensure_revisions_from_phabricator(
+    phab: PhabricatorClient, revision_ids: list[int]
+) -> list[Revision]:
+    """Return `Revision` records for each ID, fetching missing ones from Phabricator.
+
+    Existing records are returned as-is. Missing records are fetched from
+    Phabricator in batch (single API call for revisions and diffs) and saved
+    locally before being returned.
+
+    This is used when `Revision` records are needed but patches have not
+    landed on autoland yet (e.g. for pre-autoland uplift requests).
+    """
+    existing = list(Revision.objects.filter(revision_id__in=revision_ids))
+    existing_ids = {revision.revision_id for revision in existing}
+    missing_ids = [rid for rid in revision_ids if rid not in existing_ids]
+
+    if existing_ids:
+        logger.debug("Revisions already exist locally: %s.", existing_ids)
+
+    if not missing_ids:
+        return existing
+
+    logger.debug(
+        "Revisions not found locally, fetching from Phabricator: %s.", missing_ids
+    )
+
+    try:
+        revisions_by_phid = get_revisions_by_id(phab, missing_ids)
+    except ValueError as exc:
+        raise ValueError(
+            f"One or more revisions not found on Phabricator: "
+            f"{', '.join(f'D{rid}' for rid in missing_ids)}."
+        ) from exc
+
+    diff_phids = [
+        phab.expect(rev, "fields", "diffPHID") for rev in revisions_by_phid.values()
+    ]
+    diffs_by_phid = get_diffs_by_phid(phab, diff_phids)
+
+    fetched = []
+    for revision_data in revisions_by_phid.values():
+        rev_id = phab.expect(revision_data, "id")
+        diff_phid = phab.expect(revision_data, "fields", "diffPHID")
+
+        if diff_phid not in diffs_by_phid:
+            raise ValueError(f"No diff found for revision D{rev_id} on Phabricator.")
+
+        diff = diffs_by_phid[diff_phid]
+
+        # Build a primitive commit message.
+        title = phab.expect(revision_data, "fields", "title")
+        summary = revision_data["fields"].get("summary", "")
+        commit_message = f"{title}\n\n{summary}".strip()
+
+        revision = fetch_raw_diff_and_save(phab, rev_id, diff, commit_message)
+        fetched.append(revision)
+
+    return existing + fetched
+
+
+def seed_revisions_from_phabricator(
+    phab: PhabricatorClient, raw_revision_ids: list[str]
+) -> None:
+    """Ensure `Revision` records exist for each ID, fetching from Phabricator if needed.
+
+    Raises `ValueError` on the first revision ID that is not a valid integer or
+    that cannot be seeded from Phabricator.
+    """
+    revision_ids = []
+    for raw_id in raw_revision_ids:
+        try:
+            revision_ids.append(int(raw_id))
+        except (ValueError, TypeError):
+            raise ValueError(f"Invalid revision ID: {raw_id}")
+
+    if revision_ids:
+        ensure_revisions_from_phabricator(phab, revision_ids)

--- a/src/lando/api/legacy/stacks.py
+++ b/src/lando/api/legacy/stacks.py
@@ -51,6 +51,43 @@ def get_diffs_for_revision(revision: dict, all_diffs: dict[str, dict]) -> list[d
 RevisionData = namedtuple("RevisionData", ("revisions", "diffs", "repositories"))
 
 
+def request_extended_revision_data(
+    phab: PhabricatorClient, revision_phids: list[str]
+) -> RevisionData:
+    """Return a RevisionData containing extended data for revisions.
+
+    Args:
+        phab: A PhabricatorClient instance.
+        revision_phids: List of String PHIDs for revisions.
+
+    Returns:
+        A RevisionData containing extended data for a set of revisions.
+    """
+    if not revision_phids:
+        return RevisionData({}, {}, {})
+
+    revs = get_revisions_by_phid(phab, revision_phids)
+    diffs = get_diffs_by_revision_phid(phab, list(revs.keys()))
+
+    repo_phids = [phab.expect(r, "fields", "repositoryPHID") for r in revs.values()] + [
+        phab.expect(d, "fields", "repositoryPHID") for d in diffs.values()
+    ]
+    repo_phids = {phid for phid in repo_phids if phid is not None}
+    if repo_phids:
+        repos = phab.call_conduit(
+            "diffusion.repository.search",
+            attachments={"projects": True},
+            constraints={"phids": list(repo_phids)},
+            limit=len(repo_phids),
+        )
+        phab.expect(repos, "data", len(repo_phids) - 1)
+        repos = result_list_to_phid_dict(phab.expect(repos, "data"))
+    else:
+        repos = {}
+
+    return RevisionData(revs, diffs, repos)
+
+
 def get_revisions_by_phid(
     phab: PhabricatorClient, revision_phids: list[str]
 ) -> dict[str, dict]:
@@ -131,43 +168,6 @@ def get_diffs_by_phid(
         attachments={"commits": True},
     )
     return result_list_to_phid_dict(phab.expect(diffs, "data"))
-
-
-def request_extended_revision_data(
-    phab: PhabricatorClient, revision_phids: list[str]
-) -> RevisionData:
-    """Return a RevisionData containing extended data for revisions.
-
-    Args:
-        phab: A PhabricatorClient instance.
-        revision_phids: List of String PHIDs for revisions.
-
-    Returns:
-        A RevisionData containing extended data for a set of revisions.
-    """
-    if not revision_phids:
-        return RevisionData({}, {}, {})
-
-    revs = get_revisions_by_phid(phab, revision_phids)
-    diffs = get_diffs_by_revision_phid(phab, list(revs.keys()))
-
-    repo_phids = [phab.expect(r, "fields", "repositoryPHID") for r in revs.values()] + [
-        phab.expect(d, "fields", "repositoryPHID") for d in diffs.values()
-    ]
-    repo_phids = {phid for phid in repo_phids if phid is not None}
-    if repo_phids:
-        repos = phab.call_conduit(
-            "diffusion.repository.search",
-            attachments={"projects": True},
-            constraints={"phids": list(repo_phids)},
-            limit=len(repo_phids),
-        )
-        phab.expect(repos, "data", len(repo_phids) - 1)
-        repos = result_list_to_phid_dict(phab.expect(repos, "data"))
-    else:
-        repos = {}
-
-    return RevisionData(revs, diffs, repos)
 
 
 class RevisionStack(nx.DiGraph):

--- a/src/lando/api/legacy/stacks.py
+++ b/src/lando/api/legacy/stacks.py
@@ -51,21 +51,14 @@ def get_diffs_for_revision(revision: dict, all_diffs: dict[str, dict]) -> list[d
 RevisionData = namedtuple("RevisionData", ("revisions", "diffs", "repositories"))
 
 
-def request_extended_revision_data(
+def get_revisions_by_phid(
     phab: PhabricatorClient, revision_phids: list[str]
-) -> RevisionData:
-    """Return a RevisionData containing extended data for revisions.
+) -> dict[str, dict]:
+    """Fetch revisions from Phabricator by PHID.
 
-    Args:
-        phab: A landoapi.phabricator.PhabricatorClient.
-        revision_phids: List of String PHIDs for revisions.
-
-    Returns:
-        A RevisionData containing extended data for a set of revisions.
+    Returns a PHID-keyed dict of revision data with reviewer and project
+    attachments.  Raises `ValueError` if any PHID is not found.
     """
-    if not revision_phids:
-        return RevisionData({}, {}, {})
-
     revs = phab.call_conduit_collated(
         "differential.revision.search",
         constraints={"phids": revision_phids},
@@ -77,15 +70,86 @@ def request_extended_revision_data(
         raise ValueError("Mismatch in size of returned data.")
 
     phab.expect(revs, "data", len(revision_phids) - 1)
-    revs = result_list_to_phid_dict(phab.expect(revs, "data"))
+    return result_list_to_phid_dict(phab.expect(revs, "data"))
 
+
+def get_revisions_by_id(
+    phab: PhabricatorClient, revision_ids: list[int]
+) -> dict[str, dict]:
+    """Fetch revisions from Phabricator by integer ID.
+
+    Returns a PHID-keyed dict of revision data with reviewer and project
+    attachments.  Raises `ValueError` if any ID is not found.
+    """
+    revs = phab.call_conduit_collated(
+        "differential.revision.search",
+        constraints={"ids": revision_ids},
+        attachments={"reviewers": True, "reviewers-extra": True, "projects": True},
+        limit=len(revision_ids),
+    )
+
+    if len(revs["data"]) != len(revision_ids):
+        raise ValueError("Mismatch in size of returned data.")
+
+    phab.expect(revs, "data", len(revision_ids) - 1)
+    return result_list_to_phid_dict(phab.expect(revs, "data"))
+
+
+def get_diffs_by_revision_phid(
+    phab: PhabricatorClient, revision_phids: list[str]
+) -> dict[str, dict]:
+    """Fetch diffs from Phabricator for the given revision PHIDs.
+
+    Returns a PHID-keyed dict of diff data with the `commits` attachment.
+    Raises `ValueError` if fewer diffs than revisions are returned.
+    """
     diffs = phab.call_conduit_collated(
         "differential.diff.search",
         constraints={"revisionPHIDs": revision_phids},
         attachments={"commits": True},
     )
     phab.expect(diffs, "data", len(revision_phids) - 1)
-    diffs = result_list_to_phid_dict(phab.expect(diffs, "data"))
+    return result_list_to_phid_dict(phab.expect(diffs, "data"))
+
+
+def get_diffs_by_phid(
+    phab: PhabricatorClient, diff_phids: list[str]
+) -> dict[str, dict]:
+    """Fetch specific diffs from Phabricator by their PHIDs.
+
+    Unlike `get_diffs_by_revision_phid`, this fetches only the diffs with the
+    given PHIDs rather than all diffs associated with a set of revisions.
+
+    Returns a PHID-keyed dict of diff data with the `commits` attachment.
+    """
+    if not diff_phids:
+        return {}
+
+    diffs = phab.call_conduit_collated(
+        "differential.diff.search",
+        constraints={"phids": diff_phids},
+        attachments={"commits": True},
+    )
+    return result_list_to_phid_dict(phab.expect(diffs, "data"))
+
+
+def request_extended_revision_data(
+    phab: PhabricatorClient, revision_phids: list[str]
+) -> RevisionData:
+    """Return a RevisionData containing extended data for revisions.
+
+    Args:
+        phab: A PhabricatorClient instance.
+        revision_phids: List of String PHIDs for revisions.
+
+    Returns:
+        A RevisionData containing extended data for a set of revisions.
+    """
+    if not revision_phids:
+        return RevisionData({}, {}, {})
+
+    revs = get_revisions_by_phid(phab, revision_phids)
+    diffs = get_diffs_by_revision_phid(phab, list(revs.keys()))
 
     repo_phids = [phab.expect(r, "fields", "repositoryPHID") for r in revs.values()] + [
         phab.expect(d, "fields", "repositoryPHID") for d in diffs.values()

--- a/src/lando/api/tests/test_revisions.py
+++ b/src/lando/api/tests/test_revisions.py
@@ -3,9 +3,12 @@ import pytest
 from lando.api.legacy.api import stacks
 from lando.api.legacy.revisions import (
     blocker_diff_author_is_known,
+    ensure_revisions_from_phabricator,
+    fetch_raw_diff_and_save,
     revision_is_secure,
     revision_needs_testing_tag,
 )
+from lando.main.models.revision import Revision
 
 pytestmark = pytest.mark.usefixtures("docker_env_vars")
 
@@ -103,3 +106,91 @@ def test_repo_does_not_have_testing_policy(phabdouble):
     assert not revision_needs_testing_tag(
         revision, repo, ["testing-tag-phid"], "testing-policy-phid"
     )
+
+
+@pytest.mark.django_db
+def test_fetch_raw_diff_and_save_creates_new_revision(phabdouble):
+    """Creating a new `Revision` via `fetch_raw_diff_and_save`."""
+    phab_revision = phabdouble.revision(title="Bug 1 - Test commit")
+    phab = phabdouble.get_phabricator_client()
+    diff = phabdouble.api_object_for(
+        phabdouble.diff(revision=phab_revision), attachments={"commits": True}
+    )
+
+    revision = fetch_raw_diff_and_save(
+        phab, phab_revision["id"], diff, "Bug 1 - Test commit"
+    )
+
+    assert (
+        revision.revision_id == phab_revision["id"]
+    ), "`revision_id` should match the provided value."
+    assert revision.diff_id == diff["id"], "`diff_id` should match the diff."
+    assert (
+        revision.commit_message == "Bug 1 - Test commit"
+    ), "`commit_message` should be set from the provided message."
+
+
+@pytest.mark.django_db
+def test_fetch_raw_diff_and_save_updates_existing_revision(phabdouble):
+    """Updating an existing `Revision` with new data."""
+    phab_revision = phabdouble.revision(title="Updated message")
+    phab = phabdouble.get_phabricator_client()
+    diff = phabdouble.api_object_for(
+        phabdouble.diff(revision=phab_revision), attachments={"commits": True}
+    )
+    existing = Revision.objects.create(revision_id=phab_revision["id"], diff_id=1)
+
+    revision = fetch_raw_diff_and_save(
+        phab, phab_revision["id"], diff, "Updated message"
+    )
+
+    assert (
+        revision.pk == existing.pk
+    ), "Should update the existing Revision, not create a new one."
+    assert revision.diff_id == diff["id"], "`diff_id` should be updated."
+    assert (
+        revision.commit_message == "Updated message"
+    ), "`commit_message` should reflect the new data."
+
+
+@pytest.mark.django_db
+def test_ensure_revisions_from_phabricator_returns_existing(phabdouble):
+    """Returns existing `Revision` records without Phabricator API calls."""
+    existing = Revision.objects.create(revision_id=999, diff_id=1)
+    phab = phabdouble.get_phabricator_client()
+
+    revisions = ensure_revisions_from_phabricator(phab, [999])
+
+    assert len(revisions) == 1, "Should return exactly one Revision."
+    assert revisions[0].pk == existing.pk, "Should return the existing Revision."
+
+
+@pytest.mark.django_db
+def test_ensure_revisions_from_phabricator_creates_from_phabricator(phabdouble):
+    """Creates `Revision` records by fetching data from Phabricator."""
+    phab_revision = phabdouble.revision(
+        title="Bug 1 - Test patch", summary="Patch summary."
+    )
+    phab = phabdouble.get_phabricator_client()
+
+    revisions = ensure_revisions_from_phabricator(phab, [phab_revision["id"]])
+
+    assert len(revisions) == 1, "Should return exactly one Revision."
+    revision = revisions[0]
+    assert revision.revision_id == phab_revision["id"], "`revision_id` should match."
+    assert revision.diff_id is not None, "`diff_id` should be populated."
+    assert (
+        "Bug 1 - Test patch" in revision.commit_message
+    ), "`commit_message` should contain the revision title."
+    assert (
+        "Patch summary." in revision.commit_message
+    ), "`commit_message` should contain the revision summary."
+
+
+@pytest.mark.django_db
+def test_ensure_revisions_from_phabricator_raises_on_missing_revision(phabdouble):
+    """Raises `ValueError` when a revision does not exist on Phabricator."""
+    phab = phabdouble.get_phabricator_client()
+
+    with pytest.raises(ValueError, match="not found on Phabricator"):
+        ensure_revisions_from_phabricator(phab, [999999])

--- a/src/lando/api/tests/test_uplift.py
+++ b/src/lando/api/tests/test_uplift.py
@@ -260,6 +260,9 @@ def test_uplift_creation_fails_when_seeding_fails(
     response = authenticated_client.post(url, data=form_data, HTTP_REFERER="/D999999")
 
     assert response.status_code == 302, "Failed seeding should redirect."
+    assert (
+        response["Location"] == "/D999999"
+    ), "Failed seeding should redirect back to the referer."
     flash_messages = list(get_messages(response.wsgi_request))
     assert any(
         "not found on Phabricator" in str(message) for message in flash_messages

--- a/src/lando/api/tests/test_uplift.py
+++ b/src/lando/api/tests/test_uplift.py
@@ -184,7 +184,7 @@ def test_uplift_creation_uses_existing_revisions_and_links_jobs(
 
 
 @pytest.mark.django_db
-def test_uplift_creation_fails_when_revisions_missing(
+def test_uplift_creation_seeds_revisions_from_phabricator(
     authenticated_client, repo_mc, user, phabdouble
 ):
     """Test uplift creation endpoint behaviour without previous landing."""
@@ -195,38 +195,78 @@ def test_uplift_creation_fails_when_revisions_missing(
         scm_type=SCMType.GIT, name="firefox-release", approval_required=True
     )
 
+    # Create revisions in Phabricator but not in the local database.
+    phab_rev_a = phabdouble.revision(title="Bug 1 - First patch")
+    phab_rev_b = phabdouble.revision(title="Bug 1 - Second patch")
+    rev_id_a = phab_rev_a["id"]
+    rev_id_b = phab_rev_b["id"]
+
+    assert not Revision.objects.filter(
+        revision_id__in=[rev_id_a, rev_id_b]
+    ).exists(), "Revisions should not exist in the database before the request."
+
     url = reverse("uplift-page")
-
-    # NOTE: We intentionally DO NOT create a Revision(revision_id=1234) here.
-
     form_data = {
-        "source_revisions": [123, 456],
+        "source_revisions": [rev_id_a, rev_id_b],
         "repositories": [repo_a.name, repo_b.name],
     }
     form_data |= CREATE_FORM_DATA
 
-    response = authenticated_client.post(url, data=form_data, HTTP_REFERER="/D1234")
+    response = authenticated_client.post(url, data=form_data, HTTP_REFERER="/D456")
 
-    assert (
-        response.status_code == 302
-    ), "Submission missing requested revisions should redirect with error."
-    messages = list(get_messages(response.wsgi_request))
+    assert response.status_code == 302, "Successful creation should return 302."
+    flash_messages = list(get_messages(response.wsgi_request))
     assert any(
-        "has not landed on autoland yet" in str(message) for message in messages
-    ), f"Should reject with message about missing revision data: {messages=}"
+        "Uplift request queued." in str(message) for message in flash_messages
+    ), f"Successful creation should flash success: {flash_messages=}"
 
+    # Revisions should have been seeded from Phabricator.
+    assert Revision.objects.filter(
+        revision_id=rev_id_a
+    ).exists(), "Revision A should be seeded from Phabricator."
+    assert Revision.objects.filter(
+        revision_id=rev_id_b
+    ).exists(), "Revision B should be seeded from Phabricator."
+
+    # Uplift jobs should be created and linked to the seeded revisions.
     assert (
-        UpliftAssessment.objects.count() == 0
-    ), "Failed submission should not create an assessment."
+        UpliftSubmission.objects.count() == 1
+    ), "An `UpliftSubmission` should be created."
+    assert UpliftJob.objects.count() == 2, "Two uplift jobs should be created."
+
+    for job in UpliftJob.objects.all():
+        job_rev_ids = sorted(job.revisions.values_list("revision_id", flat=True))
+        assert job_rev_ids == sorted(
+            [rev_id_a, rev_id_b]
+        ), "Each job should reference the seeded revisions."
+
+
+@pytest.mark.django_db
+def test_uplift_creation_fails_when_seeding_fails(
+    authenticated_client, repo_mc, user, phabdouble
+):
+    """Test that seeding failures redirect with error flash messages."""
+    phabdouble.user(api_key=user.profile.phabricator_api_key)
+
+    repo_mc(scm_type=SCMType.GIT, name="firefox-beta", approval_required=True)
+
+    url = reverse("uplift-page")
+    form_data = {
+        "source_revisions": [999999],
+        "repositories": ["firefox-beta"],
+    }
+    form_data |= CREATE_FORM_DATA
+
+    response = authenticated_client.post(url, data=form_data, HTTP_REFERER="/D999999")
+
+    assert response.status_code == 302, "Failed seeding should redirect."
+    flash_messages = list(get_messages(response.wsgi_request))
+    assert any(
+        "not found on Phabricator" in str(message) for message in flash_messages
+    ), f"Should flash an error about the missing revision: {flash_messages=}"
     assert (
         UpliftSubmission.objects.count() == 0
-    ), "Failed submission should not create an uplift submission."
-    assert (
-        UpliftJob.objects.count() == 0
-    ), "Failed submission should not enqueue uplift jobs."
-    assert (
-        RevisionUpliftJob.objects.count() == 0
-    ), "Failed submission should not populate through rows."
+    ), "No `UpliftSubmission` should be created when seeding fails."
 
 
 def test_create_uplift_bug_update_payload():

--- a/src/lando/jinja.py
+++ b/src/lando/jinja.py
@@ -188,7 +188,7 @@ def build_manual_uplift_instructions(job: UpliftJob) -> str:
     instructions.append("git fetch origin")
     instructions.append(f"git switch -c {branch_name} origin/{default_branch}")
 
-    # Add cherry-pick commands for each revision.
+    # Add patch application commands for each revision.
     if revisions:
         for revision in revisions:
             landing_commit_id = revision.get_latest_landing_commit_id()
@@ -196,11 +196,11 @@ def build_manual_uplift_instructions(job: UpliftJob) -> str:
                 instructions.append(f"git cherry-pick {landing_commit_id}")
             else:
                 instructions.append(
-                    f"git cherry-pick <commit SHA for D{revision.revision_id}>"
+                    f"moz-phab patch D{revision.revision_id} --apply-to here"
                 )
     else:
-        instructions.append("git cherry-pick <commit-sha-1>")
-        instructions.append("# ... cherry-pick additional commits as needed")
+        instructions.append("moz-phab patch D<revision_id> --apply-to here")
+        instructions.append("# ... apply additional patches as needed")
 
     assessment_id = job.submission.assessment.id
     instructions.append(

--- a/src/lando/ui/jinja2/stack/partials/uplift-form.html
+++ b/src/lando/ui/jinja2/stack/partials/uplift-form.html
@@ -24,19 +24,6 @@
                         </div>
                     </article>
                 {% endif %}
-                {% if uplift.missing_source_revisions %}
-                    <article class="message is-danger">
-                        <div class="message-header">
-                            <p>Missing Revision Data</p>
-                        </div>
-                        <div class="message-body">
-                            The following revisions have not landed on autoland yet, so Lando does
-                            not have the revision data required to create an uplift:
-                            <strong>{{ uplift.missing_source_revisions | join(", ") }}</strong>.
-                            Please land the patch on autoland first before requesting an uplift.
-                        </div>
-                    </article>
-                {% endif %}
                 <p class="block">
                     Select the repositories you wish to uplift to and complete the
                     <strong>Uplift Assessment Form</strong> below. Lando will check your patch

--- a/src/lando/ui/jinja2/stack/partials/uplift-section.html
+++ b/src/lando/ui/jinja2/stack/partials/uplift-section.html
@@ -256,7 +256,7 @@ future.
                                                         </p>
                                                         <pre class="mt-2"><code>{{ job|build_manual_uplift_instructions }}</code></pre>
                                                         <p class="is-size-7 mt-2 has-text-grey-dark">
-                                                            Run these commands from your Firefox checkout. Resolve any merge conflicts during the cherry-pick process, then submit with <code>moz-phab uplift</code>.
+                                                            Run these commands from your Firefox checkout. Resolve any merge conflicts during the patch application process, then submit with <code>moz-phab uplift</code>.
                                                         </p>
                                                         <p class="is-size-7 mt-2 has-text-grey-dark">
                                                             <strong>Note:</strong> These commands assume your official Firefox remote is named <code>origin</code>. If you use a different remote name, adjust the commands accordingly.

--- a/src/lando/ui/legacy/forms.py
+++ b/src/lando/ui/legacy/forms.py
@@ -151,13 +151,6 @@ class UpliftRequestForm(UpliftAssessmentForm):
         queryset=Revision.objects.all(),
         to_field_name="revision_id",
         widget=forms.CheckboxSelectMultiple(),
-        error_messages={
-            "invalid_choice": (
-                "Revision D%(value)s has not landed on autoland yet, so Lando "
-                "does not have the revision data required to create an uplift. "
-                "Please land the patch on autoland first before requesting an uplift."
-            ),
-        },
     )
     repositories = forms.ModelMultipleChoiceField(
         queryset=Repo.objects.filter(approval_required=True).order_by("name"),

--- a/src/lando/ui/legacy/revisions.py
+++ b/src/lando/ui/legacy/revisions.py
@@ -11,6 +11,7 @@ from django.template.response import TemplateResponse
 from django.utils.decorators import method_decorator
 
 from lando.api.legacy import api as legacy_api
+from lando.api.legacy.revisions import seed_revisions_from_phabricator
 from lando.api.legacy.validation import parse_revision_ids
 from lando.main.auth import force_auth_refresh, require_phabricator_api_key
 from lando.main.models import Repo
@@ -40,9 +41,17 @@ logger = logging.getLogger(__name__)
 
 class UpliftRequestView(LandoView):
     @force_auth_refresh
-    @method_decorator(require_phabricator_api_key(optional=False, provide_client=False))
-    def post(self, request: WSGIRequest) -> HttpResponse:
+    @method_decorator(require_phabricator_api_key(optional=False, provide_client=True))
+    def post(self, phab: PhabricatorClient, request: WSGIRequest) -> HttpResponse:
         """Process the uplift request submission."""
+        try:
+            seed_revisions_from_phabricator(
+                phab, request.POST.getlist("source_revisions")
+            )
+        except ValueError as exc:
+            messages.add_message(request, messages.ERROR, str(exc))
+            return redirect(request.META.get("HTTP_REFERER"))
+
         uplift_request_form = UpliftRequestForm(request.POST)
 
         if not uplift_request_form.is_valid():

--- a/src/lando/ui/tests/test_template_helpers.py
+++ b/src/lando/ui/tests/test_template_helpers.py
@@ -360,3 +360,54 @@ def test_build_manual_uplift_instructions(user):
     )
 
     assert result == expected, "Generated commands should match expected."
+
+
+@pytest.mark.django_db
+def test_build_manual_uplift_instructions_no_landing_commit(user):
+    """Test manual uplift instructions when revisions have no landing commit."""
+    # Create repo with all expected fields set.
+    repo = Repo.objects.create(
+        name="firefox-beta",
+        short_name="beta",
+        default_branch="beta",
+        url="https://github.com/mozilla/gecko-dev",
+        scm_type=SCMType.GIT,
+    )
+
+    # Create revisions without any RevisionLandingJob records.
+    rev1 = Revision.objects.create(revision_id=200)
+    rev2 = Revision.objects.create(revision_id=201)
+
+    # Create assessment and submission.
+    assessment = UpliftAssessment.objects.create(
+        user=user,
+        user_impact="Test impact",
+        risk_level_explanation="Low risk",
+        string_changes="None",
+    )
+    submission = UpliftSubmission.objects.create(
+        requested_by=user,
+        assessment=assessment,
+        requested_revision_ids=[200, 201],
+    )
+
+    # Create job and link revisions.
+    job = UpliftJob.objects.create(
+        target_repo=repo, status=JobStatus.FAILED, submission=submission
+    )
+    job.add_revisions([rev1, rev2])
+    job.sort_revisions([rev1, rev2])
+
+    result = build_manual_uplift_instructions(job)
+
+    expected = (
+        "git fetch origin\n"
+        "git switch -c uplift-beta-D200 origin/beta\n"
+        "moz-phab patch D200 --apply-to here\n"
+        "moz-phab patch D201 --apply-to here\n"
+        f"moz-phab uplift --train beta --assessment-id {assessment.id}"
+    )
+
+    assert (
+        result == expected
+    ), "Revisions without landing commits should use `moz-phab patch`."

--- a/src/lando/ui/tests/test_uplift_context.py
+++ b/src/lando/ui/tests/test_uplift_context.py
@@ -3,7 +3,6 @@ from unittest.mock import MagicMock
 import pytest
 
 from lando.api.legacy.stacks import RevisionStack
-from lando.main.models import Revision
 from lando.ui.uplift.context import UpliftContext
 
 
@@ -76,32 +75,3 @@ def test_uplift_context_build_walks_stack_successfully():
         200,
         300,
     ], "Should have walked from root A through B to C."
-
-
-@pytest.mark.django_db
-@pytest.mark.parametrize(
-    "existing_ids, requested_ids, expected_missing",
-    [
-        ([100, 200], [100, 200, 300, 400], {"D300", "D400"}),
-        ([], [100, 200], {"D100", "D200"}),
-        ([100, 200], [100, 200], set()),
-        ([], [], set()),
-    ],
-    ids=[
-        "some missing",
-        "all missing",
-        "none missing",
-        "empty input",
-    ],
-)
-def test_find_missing_revisions(existing_ids, requested_ids, expected_missing):
-    """Test that `find_missing_revisions` correctly identifies revisions without DB records."""
-    for revision_id in existing_ids:
-        Revision.objects.create(revision_id=revision_id)
-
-    missing = UpliftContext.find_missing_revisions(requested_ids)
-
-    assert set(missing) == expected_missing, (
-        f"`find_missing_revisions({requested_ids})` should return `{expected_missing}` "
-        f"when revisions `{existing_ids}` exist in the database."
-    )

--- a/src/lando/ui/uplift/context.py
+++ b/src/lando/ui/uplift/context.py
@@ -9,7 +9,7 @@ from django.db.models import Prefetch, QuerySet
 
 from lando.api.legacy.stacks import RevisionStack
 from lando.api.legacy.validation import revision_id_to_int
-from lando.main.models import Repo, Revision
+from lando.main.models import Repo
 from lando.main.models.uplift import (
     UpliftAssessment,
     UpliftJob,
@@ -36,7 +36,6 @@ class UpliftContext:
     assessment: UpliftAssessment | None
     assessment_link_form: LinkUpliftAssessmentForm | None
     can_create_uplift_submission: bool
-    missing_source_revisions: tuple[str, ...]
     revision_id: int
     docs_url: str
 
@@ -68,8 +67,6 @@ class UpliftContext:
 
         request_form = UpliftRequestForm(initial={"source_revisions": source_revisions})
 
-        missing_source_revisions = cls.find_missing_revisions(source_revisions)
-
         # Look for an existing `UpliftRevision` for this revision.
         uplift_revision = UpliftRevision.one_or_none(revision_id=revision_id)
 
@@ -90,28 +87,9 @@ class UpliftContext:
             assessment_form=assessment_form,
             assessment=assessment,
             assessment_link_form=assessment_link_form,
-            can_create_uplift_submission=(
-                cls.can_create_submission(request) and not missing_source_revisions
-            ),
-            missing_source_revisions=missing_source_revisions,
+            can_create_uplift_submission=cls.can_create_submission(request),
             revision_id=revision_id,
             docs_url=UPLIFT_DOCS_URL,
-        )
-
-    @staticmethod
-    def find_missing_revisions(source_revision_ids: list[int]) -> tuple[str, ...]:
-        """Return display IDs (e.g. ``"D123"``) for revisions not found in the database.
-
-        Revisions are created when a patch lands on autoland. If a revision ID
-        is not in the database it means the patch has not landed yet and cannot
-        be used as a source for an uplift request.
-        """
-        existing_revision_ids = Revision.objects.filter(
-            revision_id__in=source_revision_ids
-        ).values_list("revision_id", flat=True)
-        return tuple(
-            f"D{rev_id}"
-            for rev_id in set(source_revision_ids) - set(existing_revision_ids)
         )
 
     @staticmethod


### PR DESCRIPTION
Previously, requesting an uplift required the patch to have already
landed on autoland so that Lando had a `Revision` record with patch
data. This blocked sec-related uplifts where developers had to wait
for sec-approval before landing on autoland, and only then could
request the uplift.

Now, when an uplift request is submitted, Lando fetches the revision
and diff data directly from Phabricator for any revisions that don't
already exist in the database.

The `Revision` creation logic from the landing POST endpoint has been
extracted into reusable helpers that both the landing and uplift
flows now share.
