### PR TITLE
api.views: add pull request description webhook (bug 2024944)

### DIFF
--- a/src/lando/api/tests/test_views.py
+++ b/src/lando/api/tests/test_views.py
@@ -4,6 +4,7 @@ import pytest
 from django.test import Client
 
 from lando.main.models import Repo, SCMType
+from lando.utils.github import PullRequest
 
 
 @pytest.fixture
@@ -284,3 +285,168 @@ def test__views__pull_request_content_api_view__missing_csrf_token(
     )
     assert result.status_code == 403
     assert b"403 Forbidden" in result.content
+
+
+@pytest.mark.parametrize(
+    "body, expected_body",
+    (
+        ("this is some commit body", "this is some commit body"),
+        # Extra whitespace before and after the commit message gets stripped.
+        (
+            "\nsomething with more characters\n\n < > <strong>test</strong> <script>\n",
+            "something with more characters\n\n < > <strong>test</strong> <script>",
+        ),
+    ),
+)
+class TestViewsPullRequestUpdateWebHook:
+    @pytest.fixture
+    def webhook_gh_client(self):
+        def wrapper(github_api_client, body):
+            data = {
+                "number": 1,
+                "title": "this is some title (bug 1111111, bug 2222222)",
+                "body": body,
+            }
+            mock_pr_data = mock.MagicMock()
+            mock_pr_data.__getitem__.side_effect = lambda k: (
+                data[k] if k in data else mock.MagicMock()
+            )
+
+            mock_github_api_client = mock.MagicMock()
+            mock_github_api_client.repo_is_private = False
+
+            mock_pr = PullRequest(mock_github_api_client, mock_pr_data)
+            mock_github_api_client.build_pull_request.return_value = mock_pr
+            github_api_client.return_value = mock_github_api_client
+
+            Repo.objects.create(
+                name="git-repo",
+                scm_type=SCMType.GIT,
+                pr_enabled=True,
+            )
+            return mock_github_api_client
+
+        return wrapper
+
+    @mock.patch("lando.api.views.generate_warnings_and_blockers")
+    @mock.patch("lando.api.views.GitHubAPIClient")
+    @pytest.mark.django_db(transaction=True)
+    def test__views__pull_request_update_webhook_warnings_and_blockers(
+        self,
+        github_api_client,
+        generate_warnings_and_blockers,
+        body,
+        expected_body,
+        client,
+        webhook_gh_client,
+    ):
+        """Test that the webhook is calling the GitHub API with the correct parameters."""
+        mock_github_api_client = webhook_gh_client(github_api_client, body)
+
+        generate_warnings_and_blockers.return_value = {
+            "warnings": ["a warning"],
+            "blockers": ["a blocker"],
+        }
+
+        test = client.post("/api/pulls/git-repo/1/webhook")
+
+        assert mock_github_api_client.update_pull_request_content.call_count == 1
+        pr_number, called_body = (
+            mock_github_api_client.update_pull_request_content.call_args[0]
+        )
+        assert pr_number == 1
+        assert called_body == "\n".join(
+            [
+                expected_body,
+                "<!--/ -+-+- DO NOT MODIFY THIS LINE - ENTER COMMIT MESSAGE ABOVE -+-+- /-->",
+                "---",
+                "Lando: [link](https://lando.test/pulls/git-repo/1/)",
+                "Bugzilla: [bug 1111111](http://bmo.test/show_bug.cgi?id=1111111), [bug 2222222](http://bmo.test/show_bug.cgi?id=2222222)",
+                "",
+                "|Warnings|",
+                "|---------|",
+                ":warning: a warning",
+                "",
+                "|Blockers|",
+                "|---------|",
+                ":no_entry_sign: a blocker",
+                "",
+            ]
+        )
+
+        assert test.status_code == 200
+        assert test.json() == {"status": "success"}
+
+    @mock.patch("lando.api.views.generate_warnings_and_blockers")
+    @mock.patch("lando.api.views.GitHubAPIClient")
+    @pytest.mark.django_db(transaction=True)
+    def test__views__pull_request_update_webhook_blockers_only(
+        self,
+        github_api_client,
+        generate_warnings_and_blockers,
+        body,
+        expected_body,
+        client,
+        webhook_gh_client,
+    ):
+        mock_github_api_client = webhook_gh_client(github_api_client, body)
+        generate_warnings_and_blockers.return_value = {
+            "warnings": [],
+            "blockers": ["a blocker"],
+        }
+
+        client.post("/api/pulls/git-repo/1/webhook")
+        assert mock_github_api_client.update_pull_request_content.call_count == 1
+        pr_number, called_body = (
+            mock_github_api_client.update_pull_request_content.call_args[0]
+        )
+
+        assert called_body == "\n".join(
+            [
+                expected_body,
+                "<!--/ -+-+- DO NOT MODIFY THIS LINE - ENTER COMMIT MESSAGE ABOVE -+-+- /-->",
+                "---",
+                "Lando: [link](https://lando.test/pulls/git-repo/1/)",
+                "Bugzilla: [bug 1111111](http://bmo.test/show_bug.cgi?id=1111111), [bug 2222222](http://bmo.test/show_bug.cgi?id=2222222)",
+                "",
+                "|Blockers|",
+                "|---------|",
+                ":no_entry_sign: a blocker",
+                "",
+            ]
+        )
+
+    @mock.patch("lando.api.views.generate_warnings_and_blockers")
+    @mock.patch("lando.api.views.GitHubAPIClient")
+    @pytest.mark.django_db(transaction=True)
+    def test__views__pull_request_update_webhook_no_warnings_or_blockers(
+        self,
+        github_api_client,
+        generate_warnings_and_blockers,
+        body,
+        expected_body,
+        client,
+        webhook_gh_client,
+    ):
+        mock_github_api_client = webhook_gh_client(github_api_client, body)
+        generate_warnings_and_blockers.return_value = {
+            "warnings": [],
+            "blockers": [],
+        }
+
+        client.post("/api/pulls/git-repo/1/webhook")
+        assert mock_github_api_client.update_pull_request_content.call_count == 1
+        pr_number, called_body = (
+            mock_github_api_client.update_pull_request_content.call_args[0]
+        )
+
+        assert called_body == "\n".join(
+            [
+                expected_body,
+                "<!--/ -+-+- DO NOT MODIFY THIS LINE - ENTER COMMIT MESSAGE ABOVE -+-+- /-->",
+                "---",
+                "Lando: [link](https://lando.test/pulls/git-repo/1/)",
+                "Bugzilla: [bug 1111111](http://bmo.test/show_bug.cgi?id=1111111), [bug 2222222](http://bmo.test/show_bug.cgi?id=2222222)",
+                ":white_check_mark: All Lando checks passed",
+            ]
+        )

--- a/src/lando/api/views.py
+++ b/src/lando/api/views.py
@@ -5,15 +5,18 @@ from functools import wraps
 from typing import Callable
 
 from django import forms
+from django.conf import settings
 from django.core.handlers.wsgi import WSGIRequest
 from django.http import Http404, HttpRequest, HttpResponse, JsonResponse
+from django.template.loader import render_to_string
+from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.utils.html import escape
 from django.views import View
 from django.views.decorators.csrf import csrf_exempt
 from requests import HTTPError
 
-from lando.api.legacy.commit_message import replace_reviewers
+from lando.api.legacy.commit_message import parse_bugs, replace_reviewers
 from lando.main.auth import PrivateRepoPermissionMixin, require_authenticated_user
 from lando.main.models import (
     CommitMap,
@@ -26,7 +29,12 @@ from lando.main.models import (
 from lando.main.models.landing_job import get_jobs_for_pull
 from lando.main.models.revision import DiffWarning, DiffWarningStatus
 from lando.main.scm import SCMType
-from lando.utils.github import GitHubAPIClient, PullRequest, PullRequestPatchHelper
+from lando.utils.github import (
+    PR_DELIMITER,
+    GitHubAPIClient,
+    PullRequest,
+    PullRequestPatchHelper,
+)
 from lando.utils.github_checks import (
     ALL_PULL_REQUEST_BLOCKERS,
     ALL_PULL_REQUEST_WARNINGS,
@@ -368,3 +376,42 @@ class PullRequestContentAPIView(PullRequestAPIView):
             form.cleaned_data["title"],
         )
         return HttpResponse(status=204)
+
+
+@method_decorator(csrf_exempt, name="dispatch")
+class PullRequestUpdateWebhook(PullRequestAPIView):
+    """API method called by GitHub to update Lando data in pull request."""
+
+    def generate_context(self, request: HttpRequest) -> dict[str, str | list[str]]:
+        """Generate various context variables used in rendering the template."""
+        context = generate_warnings_and_blockers(
+            self.target_repo, self.pull_request, request
+        )
+
+        path = reverse(
+            "pull-request",
+            kwargs={
+                "repo_name": self.target_repo.name,
+                "number": self.pull_request.number,
+            },
+        )
+
+        context["lando_url"] = f"{settings.SITE_URL}{path}"
+        context["pr_delimiter"] = PR_DELIMITER
+        bugs = parse_bugs(self.pull_request.title)
+        context["bugs"] = bugs
+        context["title"] = self.pull_request.title
+
+        # This commit body refers to the portion of the description below the
+        # delimiter (i.e., user-inputted value).
+        context["commit_body"] = self.pull_request.commit_body
+        return context
+
+    def post(
+        self, request: WSGIRequest, repo_name: str, pull_number: int
+    ) -> JsonResponse:
+        """Generate content and update PR description."""
+        context = self.generate_context(request)
+        rendered = render_to_string("pr_description.md", context)
+        self.client.update_pull_request_content(pull_number, rendered)
+        return JsonResponse({"status": "success"})

--- a/src/lando/ui/jinja2/pr_description.md
+++ b/src/lando/ui/jinja2/pr_description.md
@@ -1,0 +1,33 @@
+{# Helpers for generating warnings and blockers #}
+{% macro _warning(content) %}:warning: {{ content }}{% endmacro %}
+{% macro _blocker(content) %}:no_entry_sign: {{ content }}{% endmacro %}
+{% macro _column(content) %}|{{ content }}|{% endmacro %}
+{% macro _header() %}|---------|{% endmacro %}
+{% macro _table(title, entries, macro) %}
+{{ _column(title) }}
+{{ _header() }}
+{% for entry in entries %}
+{{ macro(entry) }}
+{% endfor %}
+{% endmacro %}
+{% block upper %}
+{{ commit_body|safe }}
+{% endblock %}
+{{ pr_delimiter|safe }}
+---
+{% block lower %}
+Lando: [link]({{ lando_url }})
+{% if bugs %}Bugzilla: {% for bug in bugs %}[bug {{ bug }}]({{ bug|bug_url }}){% if not loop.last %}, {% endif %}{% endfor %}{% endif %}
+
+{% if not warnings and not blockers %}
+:white_check_mark: All Lando checks passed
+{%- endif %}
+{% if warnings %}
+
+{{ _table("Warnings", warnings, _warning) }}
+{%- endif %}
+{% if blockers %}
+
+{{ _table("Blockers", blockers, _blocker) }}
+{%- endif %}
+{% endblock %}

--- a/src/lando/ui/jinja2/stack/pull_request.html
+++ b/src/lando/ui/jinja2/stack/pull_request.html
@@ -70,7 +70,7 @@
             <tr>
                 <th>Commit Body</th>
                 <td>
-                    <p id="commit-body">{{ pull_request.body }}</p>
+                    <p id="commit-body">{{ pull_request.commit_body|e }}</p>
                     <p id="commit-body-error"></p>
                 </td>
             </tr>

--- a/src/lando/ui/pull_requests.py
+++ b/src/lando/ui/pull_requests.py
@@ -11,7 +11,7 @@ from lando.main.models.landing_job import (
     get_jobs_for_pull,
 )
 from lando.ui.views import LandoView
-from lando.utils.github import GitHubAPIClient
+from lando.utils.github import PR_DELIMITER, GitHubAPIClient
 
 logger = logging.getLogger(__name__)
 
@@ -49,6 +49,7 @@ class PullRequestView(LandoView, PrivateRepoPermissionMixin):
             "target_repo": target_repo,
             "pull_request": pull_request,
             "landing_jobs": landing_jobs,
+            "pr_delimiter": PR_DELIMITER,
         }
 
         return TemplateResponse(

--- a/src/lando/urls.py
+++ b/src/lando/urls.py
@@ -26,6 +26,7 @@ from lando.api.views import (
     LegacyDiffWarningView,
     PullRequestChecksAPIView,
     PullRequestContentAPIView,
+    PullRequestUpdateWebhook,
     git2hgCommitMapView,
     hg2gitCommitMapView,
 )
@@ -130,6 +131,11 @@ urlpatterns += [
         "api/pulls/<str:repo_name>/<int:pull_number>",
         PullRequestContentAPIView.as_view(),
         name="api-pull-request-update-content",
+    ),
+    path(
+        "api/pulls/<str:repo_name>/<int:pull_number>/webhook",
+        PullRequestUpdateWebhook.as_view(),
+        name="api-pull-request-description",
     ),
 ]
 

--- a/src/lando/utils/github.py
+++ b/src/lando/utils/github.py
@@ -22,6 +22,11 @@ from lando.utils.const import URL_USERINFO_RE
 logger = logging.getLogger(__name__)
 
 
+PR_DELIMITER = (
+    "<!--/ -+-+- DO NOT MODIFY THIS LINE - ENTER COMMIT MESSAGE ABOVE -+-+- /-->"
+)
+
+
 class GitHub:
     """Work with authentication to GitHub repositories."""
 
@@ -242,11 +247,11 @@ class GitHubAPIClient:
         elif content_type == "application/vnd.github.diff; charset=utf-8":
             return result.text
 
-    def _post(self, path: str, *args, **kwargs):
+    def _post(self, path: str, *args, **kwargs) -> dict:
         result = self._api.post(path, *args, **kwargs)
         return result.json()
 
-    def _patch(self, path: str, *args, **kwargs):
+    def _patch(self, path: str, *args, **kwargs) -> dict:
         result = self._api.patch(path, *args, **kwargs)
         return result.json()
 
@@ -391,12 +396,15 @@ class GitHubAPIClient:
         )
 
     def update_pull_request_content(
-        self, pull_number: int, body: str, title: str
+        self, pull_number: int, body: str, title: str | None = None
     ) -> dict:
-        """Update the pull request description with provided body and title."""
+        """Update the pull request description with provided body and optional title."""
+        params = {"body": body}
+        if title is not None:
+            params["title"] = title
         return self._patch(
             f"{self.repo_base_url}/issues/{pull_number}",
-            json={"body": body, "title": title},
+            json=params,
         )
 
     @classmethod
@@ -466,6 +474,16 @@ class PullRequest:
     def __repr__(self) -> str:
         return f"Pull request #{self.number} ({self.head_repo_git_url})"
 
+    @staticmethod
+    def _parse_body_segments(body: str) -> tuple[str, str]:
+        """Return the commit body, delimited by the PR_DELIMITER or an empty string when not possible."""
+        if not body:
+            return ""
+        parts = body.split(PR_DELIMITER)
+
+        # Return the user-controlled portion.
+        return parts[0].strip()
+
     def __init__(self, client: GitHubAPIClient, data: dict):
         self.client = client
 
@@ -484,6 +502,7 @@ class PullRequest:
         self.diff_url = data["diff_url"]
         self.patch_url = data["patch_url"]
         self.body = data["body"] or ""  # description
+        self.commit_body = self._parse_body_segments(self.body)
         self.is_draft = data["draft"]
         self.comments_url = data["comments_url"]
         self.commits_url = data["commits_url"]
@@ -641,8 +660,8 @@ class PullRequest:
 
         lines = [self.title, ""]
 
-        if self.body:
-            lines += [self.body, ""]
+        if self.commit_body:
+            lines += [self.commit_body, ""]
 
         lines.append(f"Pull request: {self.html_url}")
 

--- a/src/lando/utils/tests/test_github.py
+++ b/src/lando/utils/tests/test_github.py
@@ -8,9 +8,11 @@ from django.conf import settings
 from requests import Response
 
 from lando.utils.github import (
+    PR_DELIMITER,
     GitHub,
     GitHubAPI,
     GitHubAPIClient,
+    PullRequest,
     PullRequestPatchHelper,
 )
 
@@ -445,6 +447,26 @@ def test_api_client_get_pull_request_commits(
         {"sha": "commit_21"},
         {"sha": "commit_22"},
     ], "Unexpected commit data"
+
+
+@pytest.mark.parametrize(
+    "body, expected_output",
+    (
+        ("some random text", "some random text"),
+        (
+            f"some random text{PR_DELIMITER}some other text",
+            "some random text",
+        ),
+        (
+            f"some random text{PR_DELIMITER}some other text{PR_DELIMITER}more text",
+            "some random text",
+        ),
+        ("", ""),
+    ),
+)
+def test__PullRequest___parse_body_segments__no_delimiter(body, expected_output):
+    output = PullRequest._parse_body_segments(body)
+    assert output == expected_output
 
 
 @pytest.fixture


### PR DESCRIPTION
- add view to be called by GitHub to update pull request with data from Lando
- generate pull request description containing auto-generated portion and user-inputted portion
- separate auto-generated and user-inputted portions by special delimiter
- add pr_description.md jinja2 template
- add patch methods in GitHub API client