### PR TITLE
hg: read rejects file contents in-memory (Bug 2031725)

### DIFF
--- a/src/lando/api/tests/test_hg.py
+++ b/src/lando/api/tests/test_hg.py
@@ -179,15 +179,33 @@ diff --git a/test.txt b/test.txt
 def test_integrated_hgrepo_patch_conflict_failure(hg_clone):
     repo = HgSCM(hg_clone.strpath)
 
-    # Patches with conflicts should raise a proper PatchConflict exception.
-    with pytest.raises(PatchConflict), repo.for_pull():
-        ph = HgPatchHelper.from_string_io(io.StringIO(PATCH_WITH_CONFLICT))
-        repo.apply_patch(
-            ph.get_diff(),
-            ph.get_commit_description(),
-            ph.get_header("User"),
-            ph.get_header("Date"),
-        )
+    # Patches with conflicts should raise a proper PatchConflict exception,
+    # and `process_merge_conflict` should include `.rej` file content that
+    # was captured in-memory by `clean_repo`.
+    breakdown = None
+    with pytest.raises(PatchConflict):
+        with repo.for_pull():
+            ph = HgPatchHelper.from_string_io(io.StringIO(PATCH_WITH_CONFLICT))
+            try:
+                repo.apply_patch(
+                    ph.get_diff(),
+                    ph.get_commit_description(),
+                    ph.get_header("User"),
+                    ph.get_header("Date"),
+                )
+            except PatchConflict as exc:
+                breakdown = repo.process_merge_conflict("https://hg.test", 1, str(exc))
+                raise
+
+    assert breakdown is not None, "`process_merge_conflict` should have been called."
+    assert (
+        "not-real.txt" in breakdown["rejects_paths"]
+    ), "Breakdown should include the conflicted file path."
+    reject_entry = breakdown["rejects_paths"]["not-real.txt"]
+    assert (
+        "content" in reject_entry
+    ), "Reject entry should include `.rej` content captured by `clean_repo`."
+    assert reject_entry["content"], "Reject content should not be empty."
 
 
 @pytest.mark.parametrize(
@@ -474,6 +492,53 @@ def test_HgSCM__extract_error_data():
     failed_paths, rejects_paths = HgSCM._extract_error_data(exception_message)
     assert failed_paths == expected_failed_paths
     assert rejects_paths == expected_rejects_paths
+
+
+def test_HgSCM_read_rejects_files(tmp_path: Path):
+    """Test that `read_rejects_files` returns `.rej` file contents keyed by relative path."""
+    scm = HgSCM(str(tmp_path))
+
+    # Create `.rej` files in various locations.
+    (tmp_path / "top_level.rej").write_text("reject at root")
+    nested_dir = tmp_path / "subdir" / "nested"
+    nested_dir.mkdir(parents=True)
+    (nested_dir / "deep.rej").write_text("reject in nested dir")
+
+    # Create a non-`.rej` file that should be ignored.
+    (tmp_path / "not_a_reject.txt").write_text("should be ignored")
+
+    result = scm.read_rejects_files()
+
+    assert result == {
+        "top_level.rej": "reject at root",
+        "subdir/nested/deep.rej": "reject in nested dir",
+    }, "`read_rejects_files` should return contents keyed by repo-relative path."
+
+
+def test_HgSCM_read_rejects_files_empty(tmp_path: Path):
+    """Test that `read_rejects_files` returns an empty dict when no `.rej` files exist."""
+    scm = HgSCM(str(tmp_path))
+
+    result = scm.read_rejects_files()
+
+    assert (
+        result == {}
+    ), "`read_rejects_files` should return an empty dict with no `.rej` files."
+
+
+def test_HgSCM_read_rejects_files_non_utf8(tmp_path: Path):
+    """Test that `read_rejects_files` handles non-UTF-8 content without raising."""
+    scm = HgSCM(str(tmp_path))
+
+    # Write a `.rej` file containing invalid UTF-8 bytes.
+    (tmp_path / "binary.rej").write_bytes(b"valid start \xff\xfe invalid bytes")
+
+    result = scm.read_rejects_files()
+
+    assert "binary.rej" in result, "Non-UTF-8 `.rej` file should still be included."
+    assert (
+        "\ufffd" in result["binary.rej"]
+    ), "Invalid bytes should be replaced with the Unicode replacement character."
 
 
 # The equivalent of PATCH_GIT_1 (from the git_patch() fixture), as applied to the base

--- a/src/lando/main/scm/hg.py
+++ b/src/lando/main/scm/hg.py
@@ -5,7 +5,6 @@ import os
 import posixpath
 import re
 import shlex
-import shutil
 import subprocess
 import tempfile
 import uuid
@@ -172,6 +171,7 @@ class HgSCM(AbstractSCM):
 
     def __init__(self, path: str, config: dict | None = None, **kwargs):
         self.config = copy.copy(self.DEFAULT_CONFIGS)
+        self.rejects_content: dict[str, str] = {}
 
         if config:
             self.config.update(config)
@@ -402,11 +402,8 @@ class HgSCM(AbstractSCM):
         breakdown["rejects_paths"] = {}
         for path in rejects_paths:
             reject = {"path": path}
-            try:
-                with open(self._get_rejects_path() / self.path[1:] / path, "r") as f:
-                    reject["content"] = f.read()
-            except Exception as e:
-                logger.exception(e)
+            if path in self.rejects_content:
+                reject["content"] = self.rejects_content[path]
             # Use actual path of file to store reject data, by removing
             # `.rej` extension.
             breakdown["rejects_paths"][path[:-4]] = reject
@@ -461,11 +458,6 @@ class HgSCM(AbstractSCM):
             commits.append(CommitData(**metadata))
 
         return commits
-
-    @classmethod
-    def _get_rejects_path(cls) -> Path:
-        """A Path where this SCM stores rejects from a failed patch application."""
-        return Path("/tmp/patch_rejects")
 
     @staticmethod
     def _extract_error_data(exception: str) -> tuple[list[str], list[str]]:
@@ -740,6 +732,17 @@ class HgSCM(AbstractSCM):
             logger.exception(e)
         self.hg_repo.close()
 
+    def read_rejects_files(self) -> dict[str, str]:
+        """Read all `.rej` files in the repo and return their contents.
+
+        Returns a dict mapping repo-relative paths to file contents.
+        """
+        repo_path = Path(self.path)
+        return {
+            str(reject.relative_to(repo_path)): reject.read_text(errors="replace")
+            for reject in repo_path.rglob("*.rej")
+        }
+
     @override
     def clean_repo(
         self,
@@ -751,21 +754,8 @@ class HgSCM(AbstractSCM):
 
         `attributes_override` is ignored.
         """
-        # Reset rejects directory
-        if self._get_rejects_path().is_dir():
-            shutil.rmtree(self._get_rejects_path())
-        self._get_rejects_path().mkdir()
-
-        # Copy .rej files to a temporary folder.
-        rejects = Path(f"{self.path}/").rglob("*.rej")
-        for reject in rejects:
-            os.makedirs(
-                self._get_rejects_path().joinpath(reject.parents[0].as_posix()[1:]),
-                exist_ok=True,
-            )
-            shutil.copy(
-                reject, self._get_rejects_path().joinpath(reject.as_posix()[1:])
-            )
+        # Read `.rej` file contents into memory before cleaning removes them.
+        self.rejects_content = self.read_rejects_files()
 
         # Clean working directory.
         try:


### PR DESCRIPTION
Use of the hard-coded `/tmp/rejects_path` directory to store
`.rej` file contents causes intermittent test failures during
parallelized test runs. Tests will attempt to clear the
directory during `clean_repo` and the later read file contents
in `process_merge_conflicts`, causing several different
intermittent failures from this single issue.

Change `HgSCM` to read the rejects content into an in-memory
instance variable, which is initialized empty and cleared at
the same time the previous implementation would `rmdir` the
directory. Move logic to an instance method and add a unit test
for the parsing logic. Expand tests to ensure parsing cannot fail on
invalid UTF-8, and that the in-memory rejects are properly
parsed on `PatchConflict`.
