### PR TITLE
landing_checks: block commits with REPO- flag mismatch (bug 2032267)

### DIFF
--- a/src/lando/api/legacy/commit_message.py
+++ b/src/lando/api/legacy/commit_message.py
@@ -12,6 +12,10 @@ REVISION_URL_TEMPLATE = "Differential Revision: {url}"
 # "bug" syntax like "bug X" or "b=".
 BUG_CONSERVATIVE_RE = re.compile(r"""(\b(?:bug|b=)\b(?:\s*)(\d+)(?=\b))""", re.I | re.X)
 
+# Catch REPO-<reponame> locking flags.
+REPO_FLAG_RE = re.compile(r"[\s.;]REPO-(?P<repo>[-/a-zA-Z0-9]+)(?=[\s.;]|$)")
+
+
 SPECIFIER = r"\b(?:r|a|sr|rs|ui-r)[=?]"
 SPECIFIER_RE = re.compile(SPECIFIER)
 

--- a/src/lando/api/legacy/workers/automation_worker.py
+++ b/src/lando/api/legacy/workers/automation_worker.py
@@ -102,7 +102,7 @@ class AutomationWorker(Worker):
 
             if not self.skip_checks(job, new_commits) and repo.hooks_enabled:
                 patch_helpers = repo.scm.get_patch_helpers_for_commits(new_commits)
-                landing_checks = LandingChecks(job.requester_email)
+                landing_checks = LandingChecks(job.requester_email, repo.name)
                 try:
                     check_errors = landing_checks.run(repo.hooks, patch_helpers)
                 except Exception as exc:

--- a/src/lando/api/legacy/workers/landing_worker.py
+++ b/src/lando/api/legacy/workers/landing_worker.py
@@ -339,7 +339,7 @@ class LandingWorker(Worker):
 
         if repo.hooks_enabled:
             patch_helpers = repo.scm.get_patch_helpers_for_commits(new_commits)
-            landing_checks = LandingChecks(job.requester_email)
+            landing_checks = LandingChecks(job.requester_email, repo.name)
             try:
                 check_errors = landing_checks.run(repo.hooks, patch_helpers)
             except Exception as exc:

--- a/src/lando/utils/landing_checks.py
+++ b/src/lando/utils/landing_checks.py
@@ -446,6 +446,7 @@ class PatchCollectionCheck(Check, ABC):
     """
 
     push_user_email: str | None = None
+    repo_name: str | None = None
 
     @abstractmethod
     def next_diff(self, patch_helper: PatchHelper):
@@ -672,6 +673,7 @@ class PatchCollectionAssessor:
 
     patch_helpers: Iterable[PatchHelper]
     push_user_email: str | None = None
+    repo_name: str | None = None
 
     def run_patch_collection_checks(
         self,
@@ -686,7 +688,10 @@ class PatchCollectionAssessor:
         """
         issues = []
 
-        checks = [check(self.push_user_email) for check in patch_collection_checks]
+        checks = [
+            check(self.push_user_email, self.repo_name)
+            for check in patch_collection_checks
+        ]
 
         for patch_helper in self.patch_helpers:
             # Pass the patch information into the push-wide check.
@@ -724,9 +729,11 @@ class LandingChecks:
     """Utility class to run landing checks (a.k.a. hooks) on a list of commits."""
 
     requester_email: str
+    repo_name: str
 
-    def __init__(self, requester_email: str):
+    def __init__(self, requester_email: str, repo_name: str):
         self.requester_email = requester_email
+        self.repo_name = repo_name
 
     def run(
         self,
@@ -754,7 +761,9 @@ class LandingChecks:
         stack_checks = [chk for chk in ALL_STACK_CHECKS if chk.name() in hook_names]
 
         assessor = PatchCollectionAssessor(
-            patches, push_user_email=self.requester_email
+            patches,
+            push_user_email=self.requester_email,
+            repo_name=self.repo_name,
         )
         return assessor.run_patch_collection_checks(
             patch_collection_checks=stack_checks, patch_checks=commit_checks

--- a/src/lando/utils/landing_checks.py
+++ b/src/lando/utils/landing_checks.py
@@ -20,6 +20,8 @@ from lando.api.legacy.commit_message import (
 )
 from lando.main.scm.helpers import PatchHelper
 
+REPO_FLAG_RE = re.compile(r"[\s.;]REPO-(?P<repo>[-a-zA-Z0-9]+)(?:\w|$)")
+
 
 def wrap_filenames(filenames: list[str]) -> str:
     """Convert a list of filenames to a string with names wrapped in backticks."""
@@ -510,6 +512,13 @@ class CommitMessagesCheck(PatchCollectionCheck):
                 f"git-format-patch -k to avoid this: {commit_message}"
             )
             return
+
+        if match := REPO_FLAG_RE.search(firstline):
+            if match["repo"] != self.repo_name:
+                self.commit_message_issues.append(
+                    f"Commit locked to another repo than {self.repo_name}: {commit_message}"
+                )
+                return
 
         if INVALID_REVIEW_FLAG_RE.search(firstline):
             self.commit_message_issues.append(

--- a/src/lando/utils/landing_checks.py
+++ b/src/lando/utils/landing_checks.py
@@ -14,13 +14,12 @@ from lando.api.legacy.bmo import (
 from lando.api.legacy.commit_message import (
     ACCEPTABLE_MESSAGE_FORMAT_RES,
     INVALID_REVIEW_FLAG_RE,
+    REPO_FLAG_RE,
     is_backout,
     parse_backouts,
     parse_bugs,
 )
 from lando.main.scm.helpers import PatchHelper
-
-REPO_FLAG_RE = re.compile(r"[\s.;]REPO-(?P<repo>[-/a-zA-Z0-9]+)(?=[\s.;]|$)")
 
 
 def wrap_filenames(filenames: list[str]) -> str:

--- a/src/lando/utils/landing_checks.py
+++ b/src/lando/utils/landing_checks.py
@@ -20,7 +20,7 @@ from lando.api.legacy.commit_message import (
 )
 from lando.main.scm.helpers import PatchHelper
 
-REPO_FLAG_RE = re.compile(r"[\s.;]REPO-(?P<repo>[-a-zA-Z0-9]+)(?:\w|$)")
+REPO_FLAG_RE = re.compile(r"[\s.;]REPO-(?P<repo>[-/a-zA-Z0-9]+)(?=[\s.;]|$)")
 
 
 def wrap_filenames(filenames: list[str]) -> str:
@@ -513,10 +513,16 @@ class CommitMessagesCheck(PatchCollectionCheck):
             )
             return
 
-        if match := REPO_FLAG_RE.search(firstline):
-            if match["repo"] != self.repo_name:
+        if match := REPO_FLAG_RE.findall(firstline):
+            for repo in match:
+                if "/" in repo:
+                    self.commit_message_issues.append(
+                        f"Push contains commits intended to be locked to {repo} but the repo name is badly formatted. '/' is not allowed: {commit_message}"
+                    )
+                    return
+            if self.repo_name not in match:
                 self.commit_message_issues.append(
-                    f"Commit locked to another repo than {self.repo_name}: {commit_message}"
+                    f"Commit locked to a repo other than {self.repo_name}: {commit_message}"
                 )
                 return
 

--- a/src/lando/utils/tests/test_landing_checks.py
+++ b/src/lando/utils/tests/test_landing_checks.py
@@ -221,6 +221,17 @@ diff --git a/autoland/autoland/transplant.py b/autoland/autoland/transplant.py
             "Revision with REPO- mismatch should be rejected.",
         ),
     ],
+    ids=(
+        "nobug",
+        "revert",
+        "update",
+        "bugword",
+        "backout",
+        "rq",
+        "wip",
+        "patch",
+        "repo",
+    ),
 )
 def test_check_commit_message_invalid_message(
     commit_message: str, return_string: str, error_message: str

--- a/src/lando/utils/tests/test_landing_checks.py
+++ b/src/lando/utils/tests/test_landing_checks.py
@@ -236,7 +236,9 @@ diff --git a/autoland/autoland/transplant.py b/autoland/autoland/transplant.py
 # instead of passing the url to 'hg import' to make
 ...
 """.strip()))]
-    assessor = PatchCollectionAssessor(patch_helpers=patch_helpers)
+    assessor = PatchCollectionAssessor(
+        patch_helpers=patch_helpers, repo_name="firefox-autoland"
+    )
 
     assert assessor.run_patch_collection_checks(
         patch_collection_checks=[CommitMessagesCheck], patch_checks=[]
@@ -643,7 +645,7 @@ def test_check_try_task_config():
 
 
 def test_landing_checks_run():
-    landing_checks = LandingChecks("user@example.com")
+    landing_checks = LandingChecks("user@example.com", "some-repo")
 
     # CommitMessagesCheck will get triggered twice as neither commit conform.
     patch_helpers = [

--- a/src/lando/utils/tests/test_landing_checks.py
+++ b/src/lando/utils/tests/test_landing_checks.py
@@ -293,17 +293,6 @@ def test_check_commit_message_invalid_message(
             "",
             "Commits are allowed on foo when REPO-bar is in the body rather than the title.",
         ),
-        # See next test.
-        # (
-        #     "Bug 1 - update file REPO-bar",
-        #     "Commit locked to a repo other than foo: ",
-        #     "Commits are disallowed when REPO-bar is in any commit in the push.",
-        # ),
-        # (
-        #     "Bug 1 - update file REPO-bar",
-        #     "",
-        #     "Commits locked to bar (with REPO-bar in the title) should be allowed on subdir/bar.",
-        # ),
         (
             "Bug 1 - update file REPO-subdir/bar",
             "Push contains commits intended to be locked to subdir/bar but the repo name is badly formatted. '/' is not allowed: ",

--- a/src/lando/utils/tests/test_landing_checks.py
+++ b/src/lando/utils/tests/test_landing_checks.py
@@ -329,11 +329,6 @@ def test_check_commit_message_invalid_message(
             "",
             "Commits locked to bar and foo should be allowed on foo.",
         ),
-        # (
-        #     "Bug 1 - update file\n\nREPO-foo",
-        #     "",
-        #     "Commits locked to foo (with REPO-foo in the title) should be allowed on try.",
-        # ),
     ),
 )
 def test_check_commit_message_repolocked(

--- a/src/lando/utils/tests/test_landing_checks.py
+++ b/src/lando/utils/tests/test_landing_checks.py
@@ -54,21 +54,32 @@ Let's make sure everything checks out.
 """
 
 
-def test_check_commit_message_merge_automation_empty_message():
-    patch_helpers = [HgPatchHelper.from_string_io(io.StringIO("""
+HG_PATCH_AUTHOR_COMMIT_MESSAGE_TEMPLATE = r"""
 # HG changeset patch
-# User ffxbld
+# User {author}
 # Date 1523427125 -28800
 #      Wed Apr 11 14:12:05 2018 +0800
 # Node ID 3379ea3cea34ecebdcb2cf7fb9f7845861ea8f07
 # Parent  46c36c18528fe2cc780d5206ed80ae8e37d3545d
-diff --git a/autoland/autoland/transplant.py b/autoland/autoland/transplant.py
+{commit_message}diff --git a/autoland/autoland/transplant.py b/autoland/autoland/transplant.py
 --- a/autoland/autoland/transplant.py
 +++ b/autoland/autoland/transplant.py
 @@ -318,24 +318,58 @@ class PatchTransplant(Transplant):
 # instead of passing the url to 'hg import' to make
 ...
-""".strip()))]
+""".strip()
+
+
+def test_check_commit_message_merge_automation_empty_message():
+    patch_helpers = [
+        HgPatchHelper.from_string_io(
+            io.StringIO(
+                HG_PATCH_AUTHOR_COMMIT_MESSAGE_TEMPLATE.format(
+                    author="ffxbld", commit_message=""
+                )
+            )
+        )
+    ]
 
     assessor = PatchCollectionAssessor(patch_helpers=patch_helpers)
 
@@ -81,22 +92,16 @@ diff --git a/autoland/autoland/transplant.py b/autoland/autoland/transplant.py
 
 
 def test_check_commit_message_merge_automation_bad_message():
-    patch_helpers = [HgPatchHelper.from_string_io(io.StringIO("""
-# HG changeset patch
-# User ffxbld
-# Date 1523427125 -28800
-#      Wed Apr 11 14:12:05 2018 +0800
-# Node ID 3379ea3cea34ecebdcb2cf7fb9f7845861ea8f07
-# Parent  46c36c18528fe2cc780d5206ed80ae8e37d3545d
-this message is missing the bug.
-
-diff --git a/autoland/autoland/transplant.py b/autoland/autoland/transplant.py
---- a/autoland/autoland/transplant.py
-+++ b/autoland/autoland/transplant.py
-@@ -318,24 +318,58 @@ class PatchTransplant(Transplant):
-# instead of passing the url to 'hg import' to make
-...
-""".strip()))]
+    patch_helpers = [
+        HgPatchHelper.from_string_io(
+            io.StringIO(
+                HG_PATCH_AUTHOR_COMMIT_MESSAGE_TEMPLATE.format(
+                    author="ffxbld",
+                    commit_message="this message is missing the bug\n\n",
+                )
+            )
+        )
+    ]
 
     assessor = PatchCollectionAssessor(patch_helpers=patch_helpers)
 
@@ -143,22 +148,17 @@ diff --git a/autoland/autoland/transplant.py b/autoland/autoland/transplant.py
     ],
 )
 def test_check_commit_message_valid_message(commit_message: str, error_message: str):
-    patch_helpers = [HgPatchHelper.from_string_io(io.StringIO(f"""
-# HG changeset patch
-# User Connor Sheehan <sheehan@mozilla.com>
-# Date 1523427125 -28800
-#      Wed Apr 11 14:12:05 2018 +0800
-# Node ID 3379ea3cea34ecebdcb2cf7fb9f7845861ea8f07
-# Parent  46c36c18528fe2cc780d5206ed80ae8e37d3545d
-{commit_message}
+    patch_helpers = [
+        HgPatchHelper.from_string_io(
+            io.StringIO(
+                HG_PATCH_AUTHOR_COMMIT_MESSAGE_TEMPLATE.format(
+                    author="U Ser <user@example.com>",
+                    commit_message=f"{commit_message}\n\n",
+                )
+            )
+        )
+    ]
 
-diff --git a/autoland/autoland/transplant.py b/autoland/autoland/transplant.py
---- a/autoland/autoland/transplant.py
-+++ b/autoland/autoland/transplant.py
-@@ -318,24 +318,58 @@ class PatchTransplant(Transplant):
-# instead of passing the url to 'hg import' to make
-...
-""".strip()))]
     assessor = PatchCollectionAssessor(patch_helpers=patch_helpers)
 
     assert (
@@ -236,22 +236,16 @@ diff --git a/autoland/autoland/transplant.py b/autoland/autoland/transplant.py
 def test_check_commit_message_invalid_message(
     commit_message: str, return_string: str, error_message: str
 ):
-    patch_helpers = [HgPatchHelper.from_string_io(io.StringIO(f"""
-# HG changeset patch
-# User Connor Sheehan <sheehan@mozilla.com>
-# Date 1523427125 -28800
-#      Wed Apr 11 14:12:05 2018 +0800
-# Node ID 3379ea3cea34ecebdcb2cf7fb9f7845861ea8f07
-# Parent  46c36c18528fe2cc780d5206ed80ae8e37d3545d
-{commit_message}
-
-diff --git a/autoland/autoland/transplant.py b/autoland/autoland/transplant.py
---- a/autoland/autoland/transplant.py
-+++ b/autoland/autoland/transplant.py
-@@ -318,24 +318,58 @@ class PatchTransplant(Transplant):
-# instead of passing the url to 'hg import' to make
-...
-""".strip()))]
+    patch_helpers = [
+        HgPatchHelper.from_string_io(
+            io.StringIO(
+                HG_PATCH_AUTHOR_COMMIT_MESSAGE_TEMPLATE.format(
+                    author="U Ser <user@example.com>",
+                    commit_message=f"{commit_message}\n\n",
+                )
+            )
+        )
+    ]
     assessor = PatchCollectionAssessor(
         patch_helpers=patch_helpers, repo_name="firefox-autoland"
     )

--- a/src/lando/utils/tests/test_landing_checks.py
+++ b/src/lando/utils/tests/test_landing_checks.py
@@ -256,6 +256,159 @@ def test_check_commit_message_invalid_message(
 
 
 @pytest.mark.parametrize(
+    "commit_message,return_string,error_message",
+    (
+        (
+            "Bug 1 - update file REPO-foo",
+            "",
+            "Commits locked to foo (with REPO-foo in the title) should be allowed on foo.",
+        ),
+        (
+            "Bug 1 - update file REPO-foo bar",
+            "",
+            "Commits are allowed also when REPO-foo is not last in the title.",
+        ),
+        (
+            "Bug 1 - update file REPO-FOO",
+            "Commit locked to a repo other than foo: ",
+            "Commits locked to FOO (with REPO-FOO in the title) should not be allowed on foo.",
+        ),
+        (
+            "Bug 1 - update file REPO-bar",
+            "Commit locked to a repo other than foo: ",
+            "Commits locked to bar (with REPO-bar in the title) should not be allowed on foo.",
+        ),
+        (
+            "Bug 1 - update file REPO-foo-bar",
+            "Commit locked to a repo other than foo: ",
+            "Commits locked to foo-bar should not be allowed on foo.",
+        ),
+        (
+            "Bug 1 - update file REPO-bar baz",
+            "Commit locked to a repo other than foo: ",
+            "Commits are disallowed even when REPO-bar is not last in the title.",
+        ),
+        (
+            "Bug 1 - update file\n\nREPO-bar",
+            "",
+            "Commits are allowed on foo when REPO-bar is in the body rather than the title.",
+        ),
+        # See next test.
+        # (
+        #     "Bug 1 - update file REPO-bar",
+        #     "Commit locked to a repo other than foo: ",
+        #     "Commits are disallowed when REPO-bar is in any commit in the push.",
+        # ),
+        # (
+        #     "Bug 1 - update file REPO-bar",
+        #     "",
+        #     "Commits locked to bar (with REPO-bar in the title) should be allowed on subdir/bar.",
+        # ),
+        (
+            "Bug 1 - update file REPO-subdir/bar",
+            "Push contains commits intended to be locked to subdir/bar but the repo name is badly formatted. '/' is not allowed: ",
+            "Commits locked to subdir/bar (with REPO-subdir/bar in the title) should not be allowed on subdir/bar.",
+        ),
+        (
+            "Bug 1 - update file REPO-subdir/bar",
+            "Push contains commits intended to be locked to subdir/bar but the repo name is badly formatted. '/' is not allowed: ",
+            "Commits locked to subdir/bar (with REPO-subdir/bar in the title) should not be allowed on foo.",
+        ),
+        # (
+        #     "Bug 1 - update file REPO-subdir",
+        #     "",
+        #     "Commits locked to subdir (with REPO-subdir in the title) should not be allowed on subdir/bar.",
+        # ),
+        (
+            "Bug 1 - update file REPO-foo REPO-bar",
+            "",
+            "Commits locked to foo and bar should be allowed on foo.",
+        ),
+        (
+            "Bug 1 - update file REPO-bar REPO-foo",
+            "",
+            "Commits locked to bar and foo should be allowed on foo.",
+        ),
+        # (
+        #     "Bug 1 - update file\n\nREPO-foo",
+        #     "",
+        #     "Commits locked to foo (with REPO-foo in the title) should be allowed on try.",
+        # ),
+    ),
+)
+def test_check_commit_message_repolocked(
+    commit_message: str, return_string: str, error_message: str
+):
+    patch_helpers = [
+        HgPatchHelper.from_string_io(
+            io.StringIO(
+                HG_PATCH_AUTHOR_COMMIT_MESSAGE_TEMPLATE.format(
+                    author="U Ser <user@example.com>",
+                    commit_message=f"{commit_message}\n\n",
+                )
+            )
+        )
+    ]
+    assessor = PatchCollectionAssessor(patch_helpers=patch_helpers, repo_name="foo")
+
+    expected = []
+    if return_string:
+        expected = [return_string + commit_message]
+
+    assert (
+        assessor.run_patch_collection_checks(
+            patch_collection_checks=[CommitMessagesCheck], patch_checks=[]
+        )
+        == expected
+    ), error_message
+
+
+def test_check_commit_message_repolocked_multiple():
+    commit_message = "Bug 1 - update file REPO-bar"
+    return_string = "Commit locked to a repo other than foo: "
+    error_message = "Commits are disallowed when REPO-bar is in any commit in the push."
+
+    patch_helpers = [
+        HgPatchHelper.from_string_io(
+            io.StringIO(
+                HG_PATCH_AUTHOR_COMMIT_MESSAGE_TEMPLATE.format(
+                    author="U Ser <user@example.com>",
+                    commit_message="Bug 1 - innocuous commit\n\n",
+                )
+            )
+        ),
+        HgPatchHelper.from_string_io(
+            io.StringIO(
+                HG_PATCH_AUTHOR_COMMIT_MESSAGE_TEMPLATE.format(
+                    author="U Ser <user@example.com>",
+                    commit_message=f"{commit_message}\n\n",
+                )
+            )
+        ),
+        HgPatchHelper.from_string_io(
+            io.StringIO(
+                HG_PATCH_AUTHOR_COMMIT_MESSAGE_TEMPLATE.format(
+                    author="U Ser <user@example.com>",
+                    commit_message="Bug 1 - another innocuous commit\n\n",
+                )
+            )
+        ),
+    ]
+    assessor = PatchCollectionAssessor(patch_helpers=patch_helpers, repo_name="foo")
+
+    expected = []
+    if return_string:
+        expected = [return_string + commit_message]
+
+    assert (
+        assessor.run_patch_collection_checks(
+            patch_collection_checks=[CommitMessagesCheck], patch_checks=[]
+        )
+        == expected
+    ), error_message
+
+
+@pytest.mark.parametrize(
     "push_user_email,patch,return_string,error_message",
     [
         (

--- a/src/lando/utils/tests/test_landing_checks.py
+++ b/src/lando/utils/tests/test_landing_checks.py
@@ -198,7 +198,7 @@ diff --git a/autoland/autoland/transplant.py b/autoland/autoland/transplant.py
             "Backout should be rejected when a reference to the original patch is missing.",
         ),
         (
-            "Bug 100 - Foo. r?bar",
+            "Bug 100 - Foo. r?bar REPO-firefox-autoland",
             "Revision contains 'r?' in the commit message. Please use 'r=' instead: ",
             "Improper review specifier should be rejected.",
         ),
@@ -214,6 +214,11 @@ diff --git a/autoland/autoland/transplant.py b/autoland/autoland/transplant.py
                 "Use git-format-patch -k to avoid this: "
             ),
             "`git-format-patch` cruft should result in a failed check.",
+        ),
+        (
+            "Bug 100 - Foo. r=bar REPO-elm",
+            "Commit locked to another repo than firefox-autoland: ",
+            "Revision with REPO- mismatch should be rejected.",
         ),
     ],
 )

--- a/src/lando/utils/tests/test_landing_checks.py
+++ b/src/lando/utils/tests/test_landing_checks.py
@@ -303,11 +303,6 @@ def test_check_commit_message_invalid_message(
             "Push contains commits intended to be locked to subdir/bar but the repo name is badly formatted. '/' is not allowed: ",
             "Commits locked to subdir/bar (with REPO-subdir/bar in the title) should not be allowed on foo.",
         ),
-        # (
-        #     "Bug 1 - update file REPO-subdir",
-        #     "",
-        #     "Commits locked to subdir (with REPO-subdir in the title) should not be allowed on subdir/bar.",
-        # ),
         (
             "Bug 1 - update file REPO-foo REPO-bar",
             "",

--- a/src/lando/utils/tests/test_landing_checks.py
+++ b/src/lando/utils/tests/test_landing_checks.py
@@ -217,7 +217,7 @@ def test_check_commit_message_valid_message(commit_message: str, error_message: 
         ),
         (
             "Bug 100 - Foo. r=bar REPO-elm",
-            "Commit locked to another repo than firefox-autoland: ",
+            "Commit locked to a repo other than firefox-autoland: ",
             "Revision with REPO- mismatch should be rejected.",
         ),
     ],


### PR DESCRIPTION
We use the Lando `repo.name`, e.g., firefox-autoland. This won't match the name that the VCT hook uses, e.g., autoland. This means we will need to disable the equivalent HgMO check after this has landed.

 * landing_checks: add support for `repo_name` to `LandingChecks`
 * landing_checks: block commits with `REPO-` flag mismatch  (bug 2032267)
 * tests: add `ids` to `test_check_commit_message_invalid_message`
 * tests: DRY `HG_PATCH_AUTHOR_COMMIT_MESSAGE_TEMPLATE` in `landing_checks`
 * tests: port `repolocked` tests from v-c-t