### PR TITLE
landing_jobs: expose revision info in Job JSON data (bug 2033359)

### DIFF
--- a/src/lando/api/tests/test_transplants.py
+++ b/src/lando/api/tests/test_transplants.py
@@ -874,9 +874,9 @@ def test_integrated_transplant_updated_diff_id_reflected_in_landed_phabricator_r
         result["status"] == JobStatus.SUBMITTED
     ), f"Invalid status in GET /landing_jobs/{job.id} response"
 
-    assert result[
-        "revisions"
-    ], f"Missing or empty revisions list in GET /landing_jobs/{job.id} response"
+    assert (
+        len(result["revisions"]) == 1
+    ), f"Revisions list of unexpected length in GET /landing_jobs/{job.id} response"
     assert (
         result["revisions"][0]["url"] == r1["uri"]
     ), "Incorrect revision URL in GET /landing_jobs/{job.id} response"
@@ -885,13 +885,13 @@ def test_integrated_transplant_updated_diff_id_reflected_in_landed_phabricator_r
 
     assert (
         result["revisions"][0]["author_email"] == db_revision.author_email
-    ), "Missing revision author email in GET /landing_jobs/{job.id} response"
+    ), f"Incorrect revision author email in GET /landing_jobs/{job.id} response"
     assert (
         result["revisions"][0]["author_name"] == db_revision.author_name
-    ), "Missing revision author name in GET /landing_jobs/{job.id} response"
+    ), f"Incorrect revision author name in GET /landing_jobs/{job.id} response"
     assert (
         result["revisions"][0]["commit_message"] == db_revision.commit_message
-    ), "Missing revision commitmessage in GET /landing_jobs/{job.id} response"
+    ), f"Incorrect revision commitmessage in GET /landing_jobs/{job.id} response"
 
     # Cancel job.
 

--- a/src/lando/api/tests/test_transplants.py
+++ b/src/lando/api/tests/test_transplants.py
@@ -874,6 +874,25 @@ def test_integrated_transplant_updated_diff_id_reflected_in_landed_phabricator_r
         result["status"] == JobStatus.SUBMITTED
     ), f"Invalid status in GET /landing_jobs/{job.id} response"
 
+    assert result[
+        "revisions"
+    ], f"Missing or empty revisions list in GET /landing_jobs/{job.id} response"
+    assert (
+        result["revisions"][0]["url"] == r1["uri"]
+    ), "Incorrect revision URL in GET /landing_jobs/{job.id} response"
+
+    db_revision = job.revisions[0]
+
+    assert (
+        result["revisions"][0]["author_email"] == db_revision.author_email
+    ), "Missing revision author email in GET /landing_jobs/{job.id} response"
+    assert (
+        result["revisions"][0]["author_name"] == db_revision.author_name
+    ), "Missing revision author name in GET /landing_jobs/{job.id} response"
+    assert (
+        result["revisions"][0]["commit_message"] == db_revision.commit_message
+    ), "Missing revision commitmessage in GET /landing_jobs/{job.id} response"
+
     # Cancel job.
 
     response = authenticated_client.put(

--- a/src/lando/main/models/landing_job.py
+++ b/src/lando/main/models/landing_job.py
@@ -196,7 +196,15 @@ class LandingJob(BaseJob):
 
     def to_dict(self) -> dict[str, Any]:
         job_dict = super().to_dict()
-        job_dict["revisions"] = [r.url() for r in self.revisions]
+        job_dict["revisions"] = [
+            {
+                "author_email": r.author_email,
+                "author_name": r.author_name,
+                "commit_message": r.commit_message,
+                "url": r.url(),
+            }
+            for r in self.revisions
+        ]
         job_dict["url"] = f"{settings.SITE_URL}/landings/{self.id}"
 
         return job_dict


### PR DESCRIPTION
Exposing more revision information allows consumers of the Job status JSON endpoint (at `/landing_jobs/<id>`) to display it before the stack has fully landed.

This is particularly useful for TreeHerder, and would allow users to confirm earlier that links they have received for others are correct. 