### PR TITLE
try_api: run landing checks on submission (bug 2033883)

### DIFF
--- a/src/lando/conftest.py
+++ b/src/lando/conftest.py
@@ -36,6 +36,7 @@ from lando.main.models import (
 )
 from lando.main.models.landing_job import LandingJob, add_job_with_revisions
 from lando.main.models.profile import SCM_ALLOW_DIRECT_PUSH
+from lando.main.models.repo import TRY_HOOKS
 from lando.main.models.revision import Revision
 from lando.main.scm import SCMType
 from lando.main.scm.commit import CommitData
@@ -829,6 +830,7 @@ def mocked_repo_config_try(mock_repo_config):
         short_name="try",
         is_phabricator_repo=False,
         is_try=True,
+        hooks=TRY_HOOKS,
         force_push=True,
     )
 

--- a/src/lando/conftest.py
+++ b/src/lando/conftest.py
@@ -236,9 +236,8 @@ Subject: {commit_description}
 """.strip()  # noqa: W291, `git` adds a trailing whitespace after `--`.
 
 
-    {diff}
-    -- 
-    """.rstrip()).strip()  # noqa: W291, `git` adds a trailing whitespace after `--`.
+@pytest.fixture
+def diff_to_git_patch() -> Callable:
 
     def _diff_to_git_patch(
         diff: str,

--- a/src/lando/conftest.py
+++ b/src/lando/conftest.py
@@ -9,6 +9,7 @@ import uuid
 from collections.abc import Callable, Iterable
 from datetime import datetime, timezone
 from pathlib import Path
+from textwrap import dedent
 
 import pytest
 import requests
@@ -221,6 +222,33 @@ def normal_patch():
         return _patches[number]
 
     return _patch
+
+
+@pytest.fixture
+def diff_to_git_patch() -> Callable:
+    GIT_PATCH_TEMPLATE = dedent("""
+    From daf43dabd1cc2d4f386519d61eee6e7abb766108 Mon Sep 17 00:00:00 2001
+    From: {author}
+    Date: Wed, 26 Nov 2025 04:05:36 +0000
+    Subject: {commit_description}
+
+    ---
+
+    {diff}
+    -- 
+    """.rstrip()).strip()  # noqa: W291, `git` adds a trailing whitespace after `--`.
+
+    def _diff_to_git_patch(
+        diff: str,
+        commit_description: str = "commit description",
+        author: str = "A. U. Thor <author@example.net>",
+    ) -> str:
+        """Wrap a diff in a git patch header and footer."""
+        return GIT_PATCH_TEMPLATE.format(
+            author=author, commit_description=commit_description, diff=diff.strip()
+        )
+
+    return _diff_to_git_patch
 
 
 @pytest.fixture

--- a/src/lando/conftest.py
+++ b/src/lando/conftest.py
@@ -223,13 +223,17 @@ def normal_patch():
     return _patch
 
 
-@pytest.fixture
-def diff_to_git_patch() -> Callable:
-    GIT_PATCH_TEMPLATE = dedent("""
-    From daf43dabd1cc2d4f386519d61eee6e7abb766108 Mon Sep 17 00:00:00 2001
-    From: {author}
-    Date: Wed, 26 Nov 2025 04:05:36 +0000
-    Subject: {commit_description}
+GIT_PATCH_TEMPLATE = """
+From daf43dabd1cc2d4f386519d61eee6e7abb766108 Mon Sep 17 00:00:00 2001
+From: {author}
+Date: Wed, 26 Nov 2025 04:05:36 +0000
+Subject: {commit_description}
+
+---
+
+{diff}
+-- 
+""".strip()  # noqa: W291, `git` adds a trailing whitespace after `--`.
 
     ---
 

--- a/src/lando/conftest.py
+++ b/src/lando/conftest.py
@@ -235,7 +235,6 @@ Subject: {commit_description}
 -- 
 """.strip()  # noqa: W291, `git` adds a trailing whitespace after `--`.
 
-    ---
 
     {diff}
     -- 

--- a/src/lando/conftest.py
+++ b/src/lando/conftest.py
@@ -9,7 +9,6 @@ import uuid
 from collections.abc import Callable, Iterable
 from datetime import datetime, timezone
 from pathlib import Path
-from textwrap import dedent
 
 import pytest
 import requests

--- a/src/lando/main/models/repo.py
+++ b/src/lando/main/models/repo.py
@@ -62,15 +62,6 @@ def get_default_hooks() -> list[str]:
         if hook.name != BugReferencesCheck.name()
     ]
 
-# Try repos require a slightly different set of hooks from the defaults for normal
-# repos.
-TRY_HOOKS = list(
-    # Set difference takes precedence over set union.
-    set(get_default_hooks())
-    - {CommitMessagesCheck.name()}
-    - {TryTaskConfigCheck.name()}
-    | {BugReferencesCheck.name()}
-)
 
 class Repo(BaseModel):
     """Represents the configuration of a particular repo."""
@@ -470,6 +461,8 @@ TRY_HOOKS = list(
     # Set difference takes precedence over set union.
     set(get_default_hooks())
     - {CommitMessagesCheck.name()}
+    - {PreventNSPRNSSCheck.name()}
     - {TryTaskConfigCheck.name()}
+    - {WPTSyncCheck.name()}
     | {BugReferencesCheck.name()}
 )

--- a/src/lando/main/models/repo.py
+++ b/src/lando/main/models/repo.py
@@ -16,7 +16,13 @@ from lando.main.scm import (
     AbstractSCM,
     SCMType,
 )
-from lando.utils.landing_checks import BugReferencesCheck
+from lando.utils.landing_checks import (
+    BugReferencesCheck,
+    CommitMessagesCheck,
+    PreventNSPRNSSCheck,
+    TryTaskConfigCheck,
+    WPTSyncCheck,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -56,6 +62,15 @@ def get_default_hooks() -> list[str]:
         if hook.name != BugReferencesCheck.name()
     ]
 
+# Try repos require a slightly different set of hooks from the defaults for normal
+# repos.
+TRY_HOOKS = list(
+    # Set difference takes precedence over set union.
+    set(get_default_hooks())
+    - {CommitMessagesCheck.name()}
+    - {TryTaskConfigCheck.name()}
+    | {BugReferencesCheck.name()}
+)
 
 class Repo(BaseModel):
     """Represents the configuration of a particular repo."""
@@ -446,3 +461,15 @@ class Repo(BaseModel):
 
         # If the user is not a superuser, we can skip the DB round-trip.
         return permission in user.get_user_permissions()
+
+
+# Try repos require a slightly different set of hooks from the defaults for normal
+# repos. This needs to be below the definition of Repo, so we can use it via
+# get_default_hooks.
+TRY_HOOKS = list(
+    # Set difference takes precedence over set union.
+    set(get_default_hooks())
+    - {CommitMessagesCheck.name()}
+    - {TryTaskConfigCheck.name()}
+    | {BugReferencesCheck.name()}
+)

--- a/src/lando/try_api/api.py
+++ b/src/lando/try_api/api.py
@@ -6,6 +6,7 @@ from typing import Annotated
 
 from django.core.exceptions import PermissionDenied
 from django.core.handlers.wsgi import WSGIRequest
+from django.db import transaction
 from django.http import HttpResponse, HttpResponsePermanentRedirect
 from django.shortcuts import redirect
 from ninja import NinjaAPI, Schema
@@ -229,12 +230,28 @@ def patches(
             target_commit_hash=target_commit_hash,
             status=JobStatus.CREATED,
         )
-        revisions.append(revision)
 
-    add_revisions_to_job(revisions, try_job)
+        # Create Revision objects from patches and associate them with the job.
+        revisions = []
+        for ph in patch_helpers:
+            commit_message = ph.get_commit_description()
+            diff = ph.get_diff()
 
-    try_job.status = JobStatus.SUBMITTED
-    try_job.save()
+            revision = Revision.new_from_patch(
+                raw_diff=diff,
+                patch_data={
+                    "author_name": author_name,
+                    "author_email": author_email,
+                    "commit_message": commit_message,
+                    "timestamp": timestamp,
+                },
+            )
+            revisions.append(revision)
+
+        add_revisions_to_job(revisions, try_job)
+
+        try_job.status = JobStatus.SUBMITTED
+        try_job.save()
 
     return 201, JobResponse(
         id=try_job.id,

--- a/src/lando/try_api/api.py
+++ b/src/lando/try_api/api.py
@@ -25,6 +25,7 @@ from lando.utils.exceptions import (
     ProblemException,
     problem_exception_handler,
 )
+from lando.utils.landing_checks import LandingChecks
 from lando.utils.ninja_auth import AccessTokenAuth
 
 logger = logging.getLogger(__name__)
@@ -178,17 +179,9 @@ def patches(
                 status=status,
             )
 
-    try_job = LandingJob.objects.create(
-        target_repo=repo,
-        requester_email=request.user.email,
-        target_commit_hash=target_commit_hash,
-        status=JobStatus.CREATED,
-    )
-
-    # Create Revision objects from patches and associate them with the job
-    revisions = []
+    # Create PatchHelpers and run the checks prior to creating any DB object.
     patch_helper_class = PATCH_HELPER_MAPPING[patches_request.patch_format]
-
+    patch_helpers = []
     for patch_no, patch_data in enumerate(patches_request.patches):
         # Decode the base64 patch data to bytes
         try:
@@ -202,19 +195,45 @@ def patches(
         # Create PatchHelper instance to parse the patch
         patch_io = io.BytesIO(decoded_patch_bytes)
         try:
-            patch_helper = patch_helper_class.from_bytes_io(patch_io)
+            ph = patch_helper_class.from_bytes_io(patch_io)
 
             # Extract patch information using PatchHelper
-            author_name, author_email = patch_helper.parse_author_information()
-            timestamp = patch_helper.get_timestamp()
+            author_name, author_email = ph.parse_author_information()
+            timestamp = ph.get_timestamp()
         except ValueError as exc:
             raise BadRequestProblemException(
                 title="Invalid patch data",
                 detail=f"Invalid patch data for patch {patch_no}",
             ) from exc
 
-        commit_message = patch_helper.get_commit_description()
-        diff = patch_helper.get_diff()
+        patch_helpers.append(ph)
+
+    landing_checks = LandingChecks(request.user.email, repo.name)
+    errors = landing_checks.run(
+        repo.hooks,
+        patch_helpers,
+    )
+
+    if any(errors):
+        bulleted_errors = "\n  - ".join(errors)
+        error_message = f"Patch failed checks:\n\n  - {bulleted_errors}"
+        raise BadRequestProblemException(
+            title="Errors found in pre-submission patch checks.",
+            detail=error_message,
+        )
+
+    try_job = LandingJob.objects.create(
+        target_repo=repo,
+        requester_email=request.user.email,
+        target_commit_hash=target_commit_hash,
+        status=JobStatus.CREATED,
+    )
+
+    # Create Revision objects from patches and associate them with the job.
+    revisions = []
+    for ph in patch_helpers:
+        commit_message = ph.get_commit_description()
+        diff = ph.get_diff()
 
         revision = Revision.new_from_patch(
             raw_diff=diff,

--- a/src/lando/try_api/api.py
+++ b/src/lando/try_api/api.py
@@ -252,7 +252,6 @@ def patches(
 
         add_revisions_to_job(revisions, try_job)
 
-        try_job.status = JobStatus.SUBMITTED
         try_job.save()
 
     return 201, JobResponse(

--- a/src/lando/try_api/api.py
+++ b/src/lando/try_api/api.py
@@ -228,7 +228,9 @@ def patches(
             target_repo=repo,
             requester_email=request.user.email,
             target_commit_hash=target_commit_hash,
-            status=JobStatus.CREATED,
+            # We are in a transaction, so we can mark this job as SUBMITTED rather than
+            # having a two-step process starting with CREATED.
+            status=JobStatus.SUBMITTED,
         )
 
         # Create Revision objects from patches and associate them with the job.

--- a/src/lando/try_api/api.py
+++ b/src/lando/try_api/api.py
@@ -222,27 +222,12 @@ def patches(
             detail=error_message,
         )
 
-    try_job = LandingJob.objects.create(
-        target_repo=repo,
-        requester_email=request.user.email,
-        target_commit_hash=target_commit_hash,
-        status=JobStatus.CREATED,
-    )
-
-    # Create Revision objects from patches and associate them with the job.
-    revisions = []
-    for ph in patch_helpers:
-        commit_message = ph.get_commit_description()
-        diff = ph.get_diff()
-
-        revision = Revision.new_from_patch(
-            raw_diff=diff,
-            patch_data={
-                "author_name": author_name,
-                "author_email": author_email,
-                "commit_message": commit_message,
-                "timestamp": timestamp,
-            },
+    with transaction.atomic():
+        try_job = LandingJob.objects.create(
+            target_repo=repo,
+            requester_email=request.user.email,
+            target_commit_hash=target_commit_hash,
+            status=JobStatus.CREATED,
         )
         revisions.append(revision)
 

--- a/src/lando/try_api/api.py
+++ b/src/lando/try_api/api.py
@@ -214,7 +214,7 @@ def patches(
         patch_helpers,
     )
 
-    if any(errors):
+    if errors:
         bulleted_errors = "\n  - ".join(errors)
         error_message = f"Patch failed checks:\n\n  - {bulleted_errors}"
         raise BadRequestProblemException(

--- a/src/lando/try_api/tests/test_api.py
+++ b/src/lando/try_api/tests/test_api.py
@@ -284,6 +284,54 @@ def test_try_api_patches_invalid_data(
 
 
 @pytest.mark.django_db()
+def test_try_api_patches_failed_checks(
+    mock_authenticate_builder: Callable,
+    mocked_repo_config_try: Mock,
+    scm_user: Callable,
+    commit_maps: list[CommitMap],
+    get_failing_check_diff: Callable,
+    diff_to_git_patch: Callable,
+    client_post: Callable,
+):
+    user = scm_user([Permission.objects.get(codename="scm_level_1")], "password")
+
+    mock_authenticate = mock_authenticate_builder(user)
+
+    for map in commit_maps:
+        # This is hardcoded for now.
+        map.git_repo_name = "firefox"
+        map.save()
+
+    patch_data = diff_to_git_patch(get_failing_check_diff("symlink"))
+    request_payload = {
+        # "repo": "some",  # defaults to try, from the mocked_repo_config
+        "base_commit": commit_maps[0].git_hash,
+        "base_commit_vcs": "git",
+        "patches": [
+            # Use a patch known to trigger the default set of checks.
+            base64.b64encode(patch_data.encode()).decode(),
+        ],
+        "patch_format": "git-format-patch",
+    }
+
+    response = client_post(
+        "/api/try/patches",
+        data=json.dumps(request_payload),
+        headers={"AuThOrIzAtIoN": "bEaReR token success"},
+    )
+
+    assert mock_authenticate.called, "Authentication backend should be called"
+    assert (
+        response.status_code == 400
+    ), f"Request to Try API failing checks should result in 400: {response.text}"
+
+    rj = response.json()
+    assert rj["title"] == "Errors found in pre-submission patch checks."
+    assert "Patch failed checks:" in rj["detail"]
+    assert "Revision introduces symlinks" in rj["detail"]
+
+
+@pytest.mark.django_db()
 def test_try_api_patches_success(
     mock_authenticate_builder: Callable,
     mocked_repo_config_try: Mock,

--- a/src/lando/utils/management/commands/create_environment_repos.py
+++ b/src/lando/utils/management/commands/create_environment_repos.py
@@ -12,25 +12,11 @@ from lando.main.models import (
     SCM_LEVEL_3,
     Repo,
 )
-from lando.main.models.repo import get_default_hooks
+from lando.main.models.repo import TRY_HOOKS
 from lando.main.scm import GitSCM
-from lando.utils.landing_checks import (
-    BugReferencesCheck,
-    CommitMessagesCheck,
-    TryTaskConfigCheck,
-)
 
 ENVIRONMENTS = [e for e in Environment if not e.is_test and e.is_lower]
 
-# Try repos require a slightly different set of hooks from the defaults for normal
-# repos.
-TRY_HOOKS = list(
-    # Set difference takes precedence over set union.
-    set(get_default_hooks())
-    - {TryTaskConfigCheck.name()}
-    - {CommitMessagesCheck.name()}
-    | {BugReferencesCheck.name()}
-)
 # These repos are copied from the legacy repo "subsystem".
 REPOS = {
     Environment.local: [


### PR DESCRIPTION
 * models: move `TRY_HOOKS` constant from `create_environment_repos` to `Repo`
 * models: disable NSPR and WPT checks in `TRY_HOOKS`
 * tests: set proper hooks on `mocked_repo_config_try` fixture
 * tests: add `diff_to_git_patch` fixture
 * try_api: run landing checks on submission (bug 2033883)