### PR TITLE
ui: show recent jobs on homepage when logged in (bug 1652787)

### DIFF
--- a/src/lando/static_src/legacy/css/pages/StackPage.scss
+++ b/src/lando/static_src/legacy/css/pages/StackPage.scss
@@ -329,7 +329,7 @@ ul.StackPage-blockers {
   }
   p {
       margin-top: 0;
-      margin-bottom: 0;
+      margin-bottom: 0 !important;
   }
 }
 

--- a/src/lando/ui/jinja2/home.html
+++ b/src/lando/ui/jinja2/home.html
@@ -1,7 +1,7 @@
 {% extends "partials/layout.html" %}
 {% block main %}
     <main class="container content">
-        <div id="home">
+        <section id="home">
             <h1>Welcome to Lando</h1>
             <p class="bordered">
                 Lando is an automated code lander for Mozilla.
@@ -22,6 +22,28 @@
                 For more information on Lando, consult the <a href="http://moz-conduit.readthedocs.io/en/latest/lando-user.html">user
                 guide</a>.
             </p>
-        </div>
+        </section>
+        {% if user_is_authenticated and (pending_jobs|default(False) or final_jobs|default(False)) %}
+            <section class="StackPage">
+                <h1>Your recent jobs</h1>
+                {% set embedded = True %}
+                {% if pending_jobs %}
+                    <h2>Pending</h2>
+                    <div class="StackPage-landingQueue StackPage-timeline">
+                        {% for job in pending_jobs %}
+                            {% include "partials/job.html" %}
+                        {% endfor %}
+                    </div>
+                {% endif %}
+                {% if final_jobs %}
+                    <h2>Finished (last 7 days)</h2>
+                    <div class="StackPage-landingQueue StackPage-timeline">
+                        {% for job in final_jobs %}
+                            {% include "partials/job.html" %}
+                        {% endfor %}
+                    </div>
+                {% endif %}
+            </section>
+        {% endif %}
     </main>
 {% endblock %}

--- a/src/lando/ui/jinja2/home.html
+++ b/src/lando/ui/jinja2/home.html
@@ -27,6 +27,7 @@
             <section class="StackPage">
                 <h1>Your recent jobs</h1>
                 {% set embedded = True %}
+                <h2>Pending</h2>
                 {% if pending_jobs %}
                     <h2>Pending</h2>
                     <div class="StackPage-landingQueue StackPage-timeline">

--- a/src/lando/ui/jinja2/home.html
+++ b/src/lando/ui/jinja2/home.html
@@ -37,6 +37,7 @@
                 {% else %}
                     <p>You don't have any pending job currently.</p>
                 {% endif %}
+                <h2>Finished (last {{ MAX_JOBS_HISTORY }})</h2>
                 {% if final_jobs %}
                     <h2>Finished (last 7 days)</h2>
                     <div class="StackPage-landingQueue StackPage-timeline">

--- a/src/lando/ui/jinja2/home.html
+++ b/src/lando/ui/jinja2/home.html
@@ -23,7 +23,7 @@
                 guide</a>.
             </p>
         </section>
-        {% if user_is_authenticated and (pending_jobs|default(False) or final_jobs|default(False)) %}
+        {% if user_is_authenticated and (pending_jobs|default([]) or final_jobs|default([])) %}
             <section class="StackPage">
                 <h1>Your recent jobs</h1>
                 {% set embedded = True %}

--- a/src/lando/ui/jinja2/home.html
+++ b/src/lando/ui/jinja2/home.html
@@ -44,6 +44,8 @@
                             {% include "partials/job.html" %}
                         {% endfor %}
                     </div>
+                {% else %}
+                    <p>You haven't submitted any job yet.</p>
                 {% endif %}
             </section>
         {% endif %}

--- a/src/lando/ui/jinja2/home.html
+++ b/src/lando/ui/jinja2/home.html
@@ -39,7 +39,6 @@
                 {% endif %}
                 <h2>Finished (last {{ MAX_JOBS_HISTORY }})</h2>
                 {% if final_jobs %}
-                    <h2>Finished (last 7 days)</h2>
                     <div class="StackPage-landingQueue StackPage-timeline">
                         {% for job in final_jobs %}
                             {% include "partials/job.html" %}

--- a/src/lando/ui/jinja2/home.html
+++ b/src/lando/ui/jinja2/home.html
@@ -34,6 +34,8 @@
                             {% include "partials/job.html" %}
                         {% endfor %}
                     </div>
+                {% else %}
+                    <p>You don't have any pending job currently.</p>
                 {% endif %}
                 {% if final_jobs %}
                     <h2>Finished (last 7 days)</h2>

--- a/src/lando/ui/jinja2/home.html
+++ b/src/lando/ui/jinja2/home.html
@@ -24,30 +24,31 @@
             </p>
         </section>
         {% if user_is_authenticated and (pending_jobs|default([]) or final_jobs|default([])) %}
-            <section class="StackPage">
-                <h1>Your recent jobs</h1>
-                {% set embedded = True %}
-                <h2>Pending</h2>
-                {% if pending_jobs %}
-                    <div class="StackPage-landingQueue StackPage-timeline">
-                        {% for job in pending_jobs %}
-                            {% include "partials/job.html" %}
-                        {% endfor %}
-                    </div>
-                {% else %}
-                    <p>You don't have any pending job currently.</p>
-                {% endif %}
-                <h2>Finished (last {{ MAX_JOBS_HISTORY }})</h2>
-                {% if final_jobs %}
-                    <div class="StackPage-landingQueue StackPage-timeline">
-                        {% for job in final_jobs %}
-                            {% include "partials/job.html" %}
-                        {% endfor %}
-                    </div>
-                {% else %}
-                    <p>You haven't submitted any job yet.</p>
-                {% endif %}
-            </section>
+            {% with embedded = True %}
+                <section class="StackPage">
+                    <h1>Your recent jobs</h1>
+                    <h2>Pending</h2>
+                    {% if pending_jobs %}
+                        <div class="StackPage-landingQueue StackPage-timeline">
+                            {% for job in pending_jobs %}
+                                {% include "partials/job.html" %}
+                            {% endfor %}
+                        </div>
+                    {% else %}
+                        <p>You don't have any pending job currently.</p>
+                    {% endif %}
+                    <h2>Finished (last {{ MAX_JOBS_HISTORY }})</h2>
+                    {% if final_jobs %}
+                        <div class="StackPage-landingQueue StackPage-timeline">
+                            {% for job in final_jobs %}
+                                {% include "partials/job.html" %}
+                            {% endfor %}
+                        </div>
+                    {% else %}
+                        <p>You haven't submitted any job yet.</p>
+                    {% endif %}
+                </section>
+            {% endwith %}
         {% endif %}
     </main>
 {% endblock %}

--- a/src/lando/ui/jinja2/home.html
+++ b/src/lando/ui/jinja2/home.html
@@ -29,7 +29,6 @@
                 {% set embedded = True %}
                 <h2>Pending</h2>
                 {% if pending_jobs %}
-                    <h2>Pending</h2>
                     <div class="StackPage-landingQueue StackPage-timeline">
                         {% for job in pending_jobs %}
                             {% include "partials/job.html" %}

--- a/src/lando/ui/legacy/pages.py
+++ b/src/lando/ui/legacy/pages.py
@@ -14,7 +14,7 @@ class IndexView(LandoView):
     MAX_JOBS_HISTORY = 10
 
     def get(self, request: WSGIRequest) -> TemplateResponse:
-        context = {}
+        context = {"MAX_JOBS_HISTORY": self.MAX_JOBS_HISTORY}
         if request.user.is_authenticated:
             context["pending_jobs"] = LandingJob.objects.filter(
                 requester_email=request.user.email, status__in=JobStatus.pending()

--- a/src/lando/ui/legacy/pages.py
+++ b/src/lando/ui/legacy/pages.py
@@ -1,13 +1,30 @@
+import datetime
 import logging
 
 from django.core.handlers.wsgi import WSGIRequest
 from django.template.response import TemplateResponse
 
+from lando.main.models.jobs import JobStatus
+from lando.main.models.landing_job import LandingJob
 from lando.ui.views import LandoView
 
 logger = logging.getLogger(__name__)
 
 
 class IndexView(LandoView):
+    FINAL_JOBS_MAX_DAYS = 7
+
     def get(self, request: WSGIRequest) -> TemplateResponse:
-        return TemplateResponse(request=request, template="home.html")
+        context = {}
+        if request.user.is_authenticated:
+            context["pending_jobs"] = LandingJob.objects.filter(
+                requester_email=request.user.email, status__in=JobStatus.pending()
+            )
+            context["final_jobs"] = LandingJob.objects.filter(
+                requester_email=request.user.email,
+                status__in=JobStatus.final(),
+                updated_at__gt=datetime.datetime.now()
+                - datetime.timedelta(days=self.FINAL_JOBS_MAX_DAYS),
+            )
+
+        return TemplateResponse(request=request, template="home.html", context=context)

--- a/src/lando/ui/legacy/pages.py
+++ b/src/lando/ui/legacy/pages.py
@@ -22,8 +22,6 @@ class IndexView(LandoView):
             context["final_jobs"] = LandingJob.objects.filter(
                 requester_email=request.user.email,
                 status__in=JobStatus.final(),
-                updated_at__gt=datetime.datetime.now()
-                - datetime.timedelta(days=self.FINAL_JOBS_MAX_DAYS),
-            )
+            ).order_by("-updated_at")[: self.MAX_JOBS_HISTORY]
 
         return TemplateResponse(request=request, template="home.html", context=context)

--- a/src/lando/ui/legacy/pages.py
+++ b/src/lando/ui/legacy/pages.py
@@ -1,4 +1,3 @@
-import datetime
 import logging
 
 from django.core.handlers.wsgi import WSGIRequest

--- a/src/lando/ui/legacy/pages.py
+++ b/src/lando/ui/legacy/pages.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 
 
 class IndexView(LandoView):
-    FINAL_JOBS_MAX_DAYS = 7
+    MAX_JOBS_HISTORY = 10
 
     def get(self, request: WSGIRequest) -> TemplateResponse:
         context = {}


### PR DESCRIPTION
This requires a tiny tweak to the TimeLine CSS to force `margin-bottom` to 0 in `-itemDetails` (otherwise it gets overriden by Bulma's `content`).
