### PR TITLE
scm.git: add support for cloning private repo (bug 2037928)

### DIFF
--- a/src/lando/main/scm/git.py
+++ b/src/lando/main/scm/git.py
@@ -77,6 +77,12 @@ class GitSCM(AbstractSCM):
         self.default_branch = default_branch
         super().__init__(path)
 
+    def authenticate_path_if_possible(self, path: str) -> str:
+        """Return authenticated URL if supported."""
+        if GitHub.is_supported_url(path):
+            return GitHub(path).authenticated_url
+        return path
+
     @classmethod
     @override
     def scm_type(cls) -> SCMType:
@@ -90,10 +96,12 @@ class GitSCM(AbstractSCM):
         return "Git"
 
     @override
-    def clone(self, source: str):
-        """Clone a repository from a source."""
+    def clone(self, pull_path: str):
+        """Clone a repository from a source (pull_path)."""
+        pull_path = self.authenticate_path_if_possible(pull_path)
+
         # When cloning, self.path doesn't exist yet, so we need to use another CWD.
-        self._git_run("clone", source, self.path, cwd="/")
+        self._git_run("clone", pull_path, self.path, cwd="/")
         self._git_run("checkout", self.default_branch, cwd=self.path)
         self._git_repo_config()
 
@@ -121,8 +129,7 @@ class GitSCM(AbstractSCM):
         if force_push:
             push_command += ["--force"]
 
-        if GitHub.is_supported_url(push_path):
-            push_path = GitHub(push_path).authenticated_url
+        push_path = self.authenticate_path_if_possible(push_path)
 
         push_command += [push_path]
 
@@ -466,6 +473,9 @@ class GitSCM(AbstractSCM):
 
         self.clean_repo(attributes_override=attributes_override)
         # Fetch all refs at the given pull_path, and overwrite the `origin` references.
+
+        pull_path = self.authenticate_path_if_possible(pull_path)
+
         self._git_run(
             "fetch",
             "--prune",

--- a/src/lando/main/scm/git.py
+++ b/src/lando/main/scm/git.py
@@ -77,11 +77,12 @@ class GitSCM(AbstractSCM):
         self.default_branch = default_branch
         super().__init__(path)
 
-    def authenticate_path_if_possible(self, path: str) -> str:
-        """Return authenticated URL if supported."""
-        if GitHub.is_supported_url(path):
-            return GitHub(path).authenticated_url
-        return path
+    @staticmethod
+    def authenticate_path_if_possible(url: str) -> str:
+        """Return authenticated URL if it is a GitHub URL."""
+        if GitHub.is_supported_url(url):
+            return GitHub(url).authenticated_url
+        return url
 
     @classmethod
     @override
@@ -96,9 +97,9 @@ class GitSCM(AbstractSCM):
         return "Git"
 
     @override
-    def clone(self, pull_path: str):
+    def clone(self, source: str):
         """Clone a repository from a source (pull_path)."""
-        pull_path = self.authenticate_path_if_possible(pull_path)
+        pull_path = self.authenticate_path_if_possible(source)
 
         # When cloning, self.path doesn't exist yet, so we need to use another CWD.
         self._git_run("clone", pull_path, self.path, cwd="/")

--- a/src/lando/main/tests/test_scm_helpers.py
+++ b/src/lando/main/tests/test_scm_helpers.py
@@ -2,6 +2,7 @@ import io
 import os
 from pathlib import Path
 from typing import Callable
+from unittest import mock
 
 import pytest
 
@@ -752,3 +753,21 @@ def test_strip_git_version_info_lines():
         "blah",
         "blah",
     ]
+
+
+@pytest.mark.parametrize(
+    "url,is_supported_url,result",
+    (
+        ("some_supported_url", True, "authenticated_url"),
+        ("some_unsupported_url", False, "some_unsupported_url"),
+    ),
+)
+@mock.patch("lando.main.scm.git.GitHub")
+def test_GitSCM__authenticate_path_if_possible(github, is_supported_url, url, result):
+    mock_github = mock.MagicMock()
+    type(mock_github).authenticated_url = mock.PropertyMock(return_value=result)
+    github.return_value = mock_github
+    github.is_supported_url.return_value = is_supported_url
+
+    authenticated_url = GitSCM.authenticate_path_if_possible(url)
+    assert authenticated_url == result

--- a/src/lando/main/tests/test_scm_helpers.py
+++ b/src/lando/main/tests/test_scm_helpers.py
@@ -770,4 +770,6 @@ def test_GitSCM__authenticate_path_if_possible(github, is_supported_url, url, re
     github.is_supported_url.return_value = is_supported_url
 
     authenticated_url = GitSCM.authenticate_path_if_possible(url)
+    assert github.is_supported_url.call_count == 1
+    github.is_supported_url.assert_called_with(url)
     assert authenticated_url == result

--- a/src/lando/utils/management/commands/create_environment_repos.py
+++ b/src/lando/utils/management/commands/create_environment_repos.py
@@ -28,6 +28,15 @@ REPOS = {
             "pr_enabled": True,
         },
         {
+            "name": "git-repo-private",
+            "url": "https://github.com/mozilla-conduit/test-repo-private.git",
+            "push_path": "https://github.com/mozilla-conduit/test-repo.git",
+            "required_permission": SCM_LEVEL_1,
+            "scm_type": GitSCM.scm_type(),
+            "hooks_enabled": False,
+            "pr_enabled": True,
+        },
+        {
             "name": "test-repo-git",
             "url": "http://git.test/test-repo",
             "pull_path": "http://git.test/test-repo",


### PR DESCRIPTION
- add entry to clone test repo locally
- update scm.git to use authenticated URL
- move existing path authentication functionality to reusable method