### PR TITLE
test: let test_ruff_format do its assertion (bug 2039175)

### DIFF
--- a/src/lando/tests/test_formatting.py
+++ b/src/lando/tests/test_formatting.py
@@ -9,8 +9,9 @@ from lando.settings import LINT_PATHS
 
 def test_ruff_format():
     cmd = ("ruff", "format", "--diff")
-    output = subprocess.check_output(cmd + LINT_PATHS)
-    assert not output, "The python code does not adhere to the project style."
+    output = subprocess.run(cmd + LINT_PATHS, stdout=subprocess.PIPE)
+    assert not output.stdout, "The python code does not adhere to the project style."
+    assert not output.returncode, f"{' '.join(cmd)} did not run successfully."
 
 
 def test_ruff():


### PR DESCRIPTION
`check_*` methods raise `subprocess.CalledProcessError` exceptions on non-0 status codes. This prevent the rest of the logic of the test from doing its assertions, and showing a more palatable error message to the user.