### PR TITLE
github: add ability to edit commit message from PR in Lando UI (bug 2003888)

### DIFF
--- a/src/lando/api/tests/test_views.py
+++ b/src/lando/api/tests/test_views.py
@@ -1,8 +1,25 @@
 from unittest import mock
 
 import pytest
+from django.test import Client
 
 from lando.main.models import Repo, SCMType
+
+
+@pytest.fixture
+def repo_mc_github_api_client(repo_mc):
+    repo_mc(SCMType.GIT, name="git-repo")
+
+    mock_github_api_client = mock.MagicMock()
+    mock_github_api_client.repo_is_private = False
+    return mock_github_api_client
+
+
+@pytest.fixture
+def csrf_client(user, user_plaintext_password):
+    csrf_client = Client(enforce_csrf_checks=True)
+    csrf_client.login(username=user.username, password=user_plaintext_password)
+    return csrf_client
 
 
 @pytest.mark.django_db(transaction=True)
@@ -162,3 +179,108 @@ def test__views__pull_request_api_view__private_repo(github_api_client, client):
     mock_github_api_client.repo_is_private = False
     test = client.get(f"/api/pulls/{repo.name}/1/landing_jobs")
     assert test.status_code == 200
+
+
+@mock.patch("lando.api.views.GitHubAPIClient")
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.parametrize(
+    "payload, expected_status, expected_response",
+    [
+        (
+            {
+                "title": "Valid New Title",
+                "body": "Valid New Body",
+            },
+            204,
+            b"",
+        ),
+        (
+            {
+                "title": "",
+                "body": "Valid New Body",
+            },
+            400,
+            {
+                "title": ["This field is required."],
+            },
+        ),
+        (
+            {
+                "title": "a" * 300,
+                "body": "Valid New Body",
+            },
+            400,
+            {
+                "title": ["Ensure this value has at most 256 characters (it has 300)."],
+            },
+        ),
+    ],
+)
+def test__views__pull_request_content_api_view(
+    github_api_client,
+    authenticated_client,
+    repo_mc_github_api_client,
+    payload,
+    expected_status,
+    expected_response,
+):
+    """Test PullRequestContentAPIView validation and success responses."""
+
+    github_api_client.return_value = repo_mc_github_api_client
+
+    mock_pull_request = mock.MagicMock()
+
+    repo_mc_github_api_client.build_pull_request.return_value = mock_pull_request
+    repo_mc_github_api_client.update_pull_request_content.return_value = payload
+
+    result = authenticated_client.put(
+        "/api/pulls/git-repo/100",
+        data=payload,
+        content_type="application/json",
+    )
+
+    assert result.status_code == expected_status
+
+    if expected_status == 204:
+        assert result.content == expected_response
+    else:
+        response_json = result.json()
+        for key, value in expected_response.items():
+            assert response_json.get(key) == value
+
+
+@mock.patch("lando.api.views.GitHubAPIClient")
+@pytest.mark.django_db(transaction=True)
+def test__views__pull_request_content_api_view__unauthenticated(
+    github_api_client, client, repo_mc_github_api_client
+):
+    """An anonymous PUT should be rejected by the auth decorator."""
+
+    github_api_client.return_value = repo_mc_github_api_client
+
+    result = client.put(
+        "/api/pulls/git-repo/100",
+        data={"title": "Valid New Title", "body": "Valid New Body"},
+        content_type="application/json",
+    )
+
+    # return 403 instead of 401 due to bug with django auth decorator. See: https://github.com/django/django/blob/main/django/core/handlers/exception.py#L75C51-L75C54
+    assert result.status_code == 403
+    assert b"403 Forbidden" in result.content
+
+
+@mock.patch("lando.api.views.GitHubAPIClient")
+@pytest.mark.django_db(transaction=True)
+def test__views__pull_request_content_api_view__missing_csrf_token(
+    github_api_client, csrf_client, repo_mc_github_api_client
+):
+    """An authenticated PUT without a CSRF token should be rejected."""
+    github_api_client.return_value = repo_mc_github_api_client
+
+    result = csrf_client.put(
+        "/api/pulls/git-repo/100",
+        data={"title": "Valid New Title", "body": "Valid New Body"},
+        content_type="application/json",
+    )
+    assert result.status_code == 403
+    assert b"403 Forbidden" in result.content

--- a/src/lando/api/views.py
+++ b/src/lando/api/views.py
@@ -6,7 +6,7 @@ from typing import Callable
 
 from django import forms
 from django.core.handlers.wsgi import WSGIRequest
-from django.http import Http404, HttpRequest, JsonResponse
+from django.http import Http404, HttpRequest, HttpResponse, JsonResponse
 from django.utils.decorators import method_decorator
 from django.utils.html import escape
 from django.views import View
@@ -214,7 +214,11 @@ class PullRequestAPIView(View, PrivateRepoPermissionMixin):
     def dispatch(
         self, request: WSGIRequest, repo_name: str, pull_number: int, *args, **kwargs
     ) -> JsonResponse:
-        self.target_repo = Repo.objects.get(name=repo_name)
+        try:
+            self.target_repo = Repo.objects.get(name=repo_name)
+        except Repo.DoesNotExist as e:
+            raise Http404 from e
+
         self.client = GitHubAPIClient(self.target_repo.url)
         self.raise_404_if_needed(request, self.client)
 
@@ -334,3 +338,33 @@ class PullRequestChecksAPIView(PullRequestAPIView):
             # The StaleMetadataException error message is safe for user consumption.
             return JsonResponse({"errors": [str(exc)]}, status=500)
         return JsonResponse(warnings_and_blockers)
+
+
+class PullRequestContentAPIView(PullRequestAPIView):
+    """Handle pull request content updates in the API."""
+
+    @method_decorator(require_authenticated_user)
+    def put(
+        self, request: WSGIRequest, repo_name: str, pull_number: int
+    ) -> JsonResponse:
+        """Update pull request content"""
+        if not self.target_repo.user_can_push(request.user):
+            return JsonResponse(
+                {"errors": ["You do not have permission to modify this pull request."]},
+                status=403,
+            )
+
+        class Form(forms.Form):
+            body = forms.CharField(required=False)
+            title = forms.CharField(max_length=256)
+
+        form = Form(json.loads(request.body))
+        if not form.is_valid():
+            return JsonResponse(form.errors, status=400)
+
+        self.client.update_pull_request_content(
+            self.pull_request.number,
+            form.cleaned_data["body"],
+            form.cleaned_data["title"],
+        )
+        return HttpResponse(status=204)

--- a/src/lando/static_src/legacy/css/pages/StackPage.scss
+++ b/src/lando/static_src/legacy/css/pages/StackPage.scss
@@ -31,6 +31,19 @@
   & table {
     margin-bottom: 0;
   }
+
+  #commit-title,
+  #commit-body {
+    font-family: "Fira Mono", monospace;
+  }
+
+  #commit-title {
+    min-height: 50px;
+  }
+
+  #commit-body {
+    min-height: 75px;
+  }
 }
 
 .StackPage-revision {

--- a/src/lando/static_src/legacy/js/components/Stack.js
+++ b/src/lando/static_src/legacy/js/components/Stack.js
@@ -137,7 +137,7 @@ $.fn.stack = function () {
               method: "GET",
             }).then(async (response) => {
               $("#save-edit-pr").prop("disabled", false);
-              if (response.status == 204) {
+              if (response.status == 200) {
                 var result = await response.json();
                 var blockers = result.blockers;
                 var warnings = result.warnings;
@@ -264,7 +264,7 @@ $.fn.stack = function () {
               "X-CSRFToken": csrf_token,
             },
           }).then(async (response) => {
-            if (response.status === 200) {
+            if (response.status === 204) {
               $("#commit-title-error").text("");
               $("#commit-body-error").text("");
               $("#commit-title").removeClass("is-danger");

--- a/src/lando/static_src/legacy/js/components/Stack.js
+++ b/src/lando/static_src/legacy/js/components/Stack.js
@@ -79,8 +79,9 @@ $.fn.stack = function () {
     // This should be cleaned up as part of bug 1995754.
     var is_pull_request_page = Boolean($("button.post-landing-job").length);
     if (is_pull_request_page) {
+      var saved_landing_state = null;
       var pull_request_button = $("button.post-landing-job");
-
+      $("#save-edit-pr").prop("disabled", true);
       $("#acknowledge-warnings").on("click", function () {
         if (this.checked) {
           pull_request_button.prop("disabled", false);
@@ -135,6 +136,7 @@ $.fn.stack = function () {
             fetch(`/api/pulls/${repo_name}/${pull_number}/checks`, {
               method: "GET",
             }).then(async (response) => {
+              $("#save-edit-pr").prop("disabled", false);
               if (response.status == 200) {
                 var result = await response.json();
                 var blockers = result.blockers;
@@ -186,6 +188,15 @@ $.fn.stack = function () {
                     .addClass("is-warning");
                   pull_request_button.html("Acknowledge warnings to continue");
                 }
+                saved_landing_state = {
+                  html: pull_request_button.html(),
+                  disabled: pull_request_button.prop("disabled"),
+                  classes: pull_request_button.attr("class"),
+                  ack_section_visible: $(".acknowledge-warnings-section").is(
+                    ":visible",
+                  ),
+                  ack_checked: $("#acknowledge-warnings").prop("checked"),
+                };
               } else {
                 // TODO: handle this case. See bug 1996000.
               }
@@ -225,6 +236,141 @@ $.fn.stack = function () {
             pull_request_button.html("An unknown error occurred");
           }
         });
+      });
+
+      $("#save-edit-pr").on("click", function (e) {
+        var save_edit_pr_button = $(this);
+        var pull_request_button = $("#post-landing-job");
+
+        pull_request_button.prop("disabled", true);
+        pull_request_button.addClass("is-danger");
+        pull_request_button.html("Landing is blocked");
+        $(".acknowledge-warnings-section").hide();
+
+        if (save_edit_pr_button.attr("data-mode") === "edit") {
+          var body = $("#commit-body").val();
+          var title = $("#commit-title").val();
+          save_edit_pr_button.prop("disabled", true);
+          save_edit_pr_button.addClass("is-loading");
+          $("#cancel-edit-pr").prop("disabled", true);
+          $("#commit-title").prop("disabled", true);
+          $("#commit-body").prop("disabled", true);
+          fetch(`/api/pulls/${repo_name}/${pull_number}`, {
+            method: "PUT",
+            body: JSON.stringify({ body: body, title: title }),
+            headers: {
+              Accept: "application/json",
+              "Content-Type": "application/json",
+              "X-CSRFToken": csrf_token,
+            },
+          }).then(async (response) => {
+            if (response.status === 200) {
+              $("#commit-title-error").text("");
+              $("#commit-body-error").text("");
+              $("#commit-title").removeClass("is-danger");
+              $("#commit-body").removeClass("is-danger");
+              window.location.reload();
+            } else {
+              if (response.status >= 400 && response.status < 500) {
+                var result = await response.json();
+                save_edit_pr_button.removeClass("is-loading");
+                $("#cancel-edit-pr").prop("disabled", false);
+                if (result.title) {
+                  $("#commit-title-error").text(result.title);
+                  $("#commit-title-error").addClass("help is-danger");
+                  $("#commit-title").prop("disabled", false);
+                  $("#commit-body").prop("disabled", false);
+                  $("#commit-title").addClass("is-danger");
+                }
+                if (result.body) {
+                  $("#commit-body-error").text(result.body);
+                  $("#commit-body-error").addClass("help is-danger");
+                  $("#commit-title").prop("disabled", false);
+                  $("#commit-body").prop("disabled", false);
+                  $("#commit-body").addClass("is-danger");
+                }
+              } else {
+                save_edit_pr_button
+                  .prop("disabled", true)
+                  .removeClass("is-danger is-loading")
+                  .addClass("is-warning")
+                  .text("An unknown error occurred");
+              }
+            }
+          });
+          return;
+        }
+
+        const pTitle = $("#commit-title");
+        const pBody = $("#commit-body");
+        const textareaTitle = $("<textarea>")
+          .attr("id", "commit-title")
+          .addClass("textarea")
+          .val(pTitle.text())
+          .attr("data-original", pTitle.text());
+        const textareaBody = $("<textarea>")
+          .attr("id", "commit-body")
+          .addClass("textarea")
+          .val(pBody.text())
+          .attr("data-original", pBody.text());
+
+        pTitle.replaceWith(textareaTitle);
+        pBody.replaceWith(textareaBody);
+
+        save_edit_pr_button
+          .attr("data-mode", "edit")
+          .text("Save Commit Message");
+        $("#cancel-edit-pr").removeClass("is-hidden");
+        $("#commit-title").focus();
+        $("#post-landing-job").prop("disabled", true);
+
+        textareaTitle.on("input", function () {
+          $("#commit-title").removeClass("is-danger");
+          $("#commit-title-error").text("");
+          save_edit_pr_button.prop("disabled", false);
+        });
+
+        textareaBody.on("input", function () {
+          $("#commit-body").removeClass("is-danger");
+          $("#commit-body-error").text("");
+          save_edit_pr_button.prop("disabled", false);
+        });
+      });
+
+      $("#cancel-edit-pr").on("click", function (e) {
+        var pull_request_button = $("#post-landing-job");
+        if (saved_landing_state) {
+          pull_request_button.html(saved_landing_state.html);
+          pull_request_button.prop("disabled", saved_landing_state.disabled);
+          pull_request_button.attr("class", saved_landing_state.classes);
+          $(".acknowledge-warnings-section").toggle(
+            saved_landing_state.ack_section_visible,
+          );
+          $("#acknowledge-warnings").prop(
+            "checked",
+            saved_landing_state.ack_checked,
+          );
+        }
+        const pTitle = document.createElement("p");
+        const pBody = document.createElement("p");
+        const textareaTitle = $("#commit-title");
+        const textareaBody = $("#commit-body");
+        pTitle.textContent = textareaTitle.data("original");
+        pBody.textContent = textareaBody.data("original");
+        pTitle.id = "commit-title";
+        pBody.id = "commit-body";
+        textareaTitle.replaceWith(pTitle);
+        textareaBody.replaceWith(pBody);
+
+        const save_edit_pr_button = $("#save-edit-pr");
+        save_edit_pr_button.prop("disabled", false);
+        save_edit_pr_button
+          .attr("data-mode", "saved")
+          .text("Edit Commit Message");
+
+        $("#commit-title-error").text("");
+        $("#commit-body-error").text("");
+        $("#cancel-edit-pr").addClass("is-hidden");
       });
     }
   });

--- a/src/lando/static_src/legacy/js/components/Stack.js
+++ b/src/lando/static_src/legacy/js/components/Stack.js
@@ -137,7 +137,7 @@ $.fn.stack = function () {
               method: "GET",
             }).then(async (response) => {
               $("#save-edit-pr").prop("disabled", false);
-              if (response.status == 200) {
+              if (response.status == 204) {
                 var result = await response.json();
                 var blockers = result.blockers;
                 var warnings = result.warnings;

--- a/src/lando/ui/jinja2/stack/pull_request.html
+++ b/src/lando/ui/jinja2/stack/pull_request.html
@@ -6,7 +6,8 @@
             <a href="{{ pull_request.html_url }}">{{ pull_request.title }}</a> #{{ pull_request.number }} ({{ target_repo.name }}@{{ target_repo.default_branch }})
         </h1>
         <p>
-            <button class="button is-large is-loading post-landing-job has-text-white"
+            <button id="post-landing-job"
+                    class="button is-large is-loading post-landing-job has-text-white"
                     disabled
                     data-anonymous="{{ '0' if request.user.is_authenticated else '1' }}"
                     data-pull-number="{{ pull_request.number }}"
@@ -61,13 +62,28 @@
             </tr>
             <tr>
                 <th>Commit Title</th>
-                <td>{{ pull_request.title }}</td>
+                <td>
+                    <p id="commit-title">{{ pull_request.title }}</p>
+                    <p id="commit-title-error"></p>
+                </td>
             </tr>
             <tr>
                 <th>Commit Body</th>
-                <td>{{ pull_request.body }}</td>
+                <td>
+                    <p id="commit-body">{{ pull_request.body }}</p>
+                    <p id="commit-body-error"></p>
+                </td>
             </tr>
         </table>
+        <p>
+            <button id="save-edit-pr"
+                    class="button"
+                    data-mode="saved"
+                    data-pull-number="{{ pull_request.number }}"
+                    data-repo-name="{{ target_repo.name }}"
+                    data-csrf-token="{{ csrf_token }}">Edit Commit Message</button>
+            <button id="cancel-edit-pr" class="button is-light is-hidden">Cancel</button>
+        </p>
     </div>
     <h1>Landings</h1>
     {% include "stack/partials/timeline.html" %}

--- a/src/lando/urls.py
+++ b/src/lando/urls.py
@@ -25,6 +25,7 @@ from lando.api.views import (
     LandingJobPullRequestAPIView,
     LegacyDiffWarningView,
     PullRequestChecksAPIView,
+    PullRequestContentAPIView,
     git2hgCommitMapView,
     hg2gitCommitMapView,
 )
@@ -124,6 +125,11 @@ urlpatterns += [
         "api/pulls/<str:repo_name>/<int:pull_number>/checks",
         PullRequestChecksAPIView.as_view(),
         name="api-pull-request-checks",
+    ),
+    path(
+        "api/pulls/<str:repo_name>/<int:pull_number>",
+        PullRequestContentAPIView.as_view(),
+        name="api-pull-request-update-content",
     ),
 ]
 

--- a/src/lando/utils/github.py
+++ b/src/lando/utils/github.py
@@ -150,6 +150,11 @@ class GitHubAPI(GitHub):
         url = f"{self.GITHUB_BASE_URL}/{path}"
         return self.session.post(url, *args, **kwargs)
 
+    def patch(self, path: str, *args, **kwargs) -> requests.Response:
+        """Send a PATCH request to the GitHub API with given args and kwargs."""
+        url = f"{self.GITHUB_BASE_URL}/{path}"
+        return self.session.patch(url, *args, **kwargs)
+
 
 class GitHubAPIClient:
     """A convenience client that provides various methods to interact with the GitHub API."""
@@ -239,6 +244,10 @@ class GitHubAPIClient:
 
     def _post(self, path: str, *args, **kwargs):
         result = self._api.post(path, *args, **kwargs)
+        return result.json()
+
+    def _patch(self, path: str, *args, **kwargs):
+        result = self._api.patch(path, *args, **kwargs)
         return result.json()
 
     def build_pull_request(self, pull_number: int) -> "PullRequest":
@@ -381,6 +390,15 @@ class GitHubAPIClient:
             json={"body": comment},
         )
 
+    def update_pull_request_content(
+        self, pull_number: int, body: str, title: str
+    ) -> dict:
+        """Update the pull request description with provided body and title."""
+        return self._patch(
+            f"{self.repo_base_url}/issues/{pull_number}",
+            json={"body": body, "title": title},
+        )
+
     @classmethod
     def convert_timestamp_from_github(cls, timestamp: str) -> str:
         timestamp_datetime = datetime.fromisoformat(timestamp)
@@ -461,7 +479,7 @@ class PullRequest:
         self.merged_at = data["merged_at"]
         self.diff_url = data["diff_url"]
         self.patch_url = data["patch_url"]
-        self.body = data["body"]  # description
+        self.body = data["body"] or ""  # description
         self.is_draft = data["draft"]
         self.comments_url = data["comments_url"]
         self.commits_url = data["commits_url"]


### PR DESCRIPTION
- Added a view callable by GitHub to update pull request content with data from Lando
- Added editable commit body and title fields in the PR UI
  - Land button is disabled while fields are being edited to prevent landing stale content
- Added an "Edit" and "Save" commit message button that refreshes the page on submit + cancel changes button
  - Text areas are disabled during save to prevent concurrent edits
- Added error display for invalid input

Demo of UI:

https://github.com/user-attachments/assets/a8e09848-c810-4d01-bf3f-c252a379f418




