### PR TITLE
tests: add `test_migrations.py` to check migration integrity (Bug 2041054)

### DIFF
--- a/src/lando/tests/test_migrations.py
+++ b/src/lando/tests/test_migrations.py
@@ -1,0 +1,18 @@
+from django.db.migrations.loader import MigrationLoader
+from django.test import override_settings
+
+
+def test_no_migration_conflicts():
+    """Each app's migration graph must have exactly one leaf node."""
+    # `connection=None` skips the DB. `MIGRATION_MODULES={}` defeats
+    # `pytest-django`'s `--no-migrations` patch, which would otherwise
+    # hide every migration from the loader once `django_db_setup` runs.
+    with override_settings(MIGRATION_MODULES={}):
+        loader = MigrationLoader(connection=None, ignore_no_migrations=True)
+        conflicts = loader.detect_conflicts()
+
+    assert not conflicts, (
+        "Conflicting migrations detected (multiple leaf nodes per app): "
+        f"{conflicts}. Renumber/rebase the offending migration or run "
+        "`makemigrations --merge`."
+    )

--- a/src/lando/tests/test_migrations.py
+++ b/src/lando/tests/test_migrations.py
@@ -13,6 +13,6 @@ def test_no_migration_conflicts():
 
     assert not conflicts, (
         "Conflicting migrations detected (multiple leaf nodes per app): "
-        f"{conflicts}. Renumber/rebase the offending migration or run "
-        "`makemigrations --merge`."
+        f"{conflicts}. Check any new migration files that may need to be "
+        "regenerated."
     )

--- a/src/lando/tests/test_migrations.py
+++ b/src/lando/tests/test_migrations.py
@@ -3,7 +3,7 @@ from django.test import override_settings
 
 
 def test_no_migration_conflicts():
-    """Each app's migration graph must have exactly one leaf node."""
+    """Test that each app's migration graph has exactly one leaf node."""
     # `connection=None` skips the DB. `MIGRATION_MODULES={}` defeats
     # `pytest-django`'s `--no-migrations` patch, which would otherwise
     # hide every migration from the loader once `django_db_setup` runs.


### PR DESCRIPTION
Add `test_migrations.py` which contains a single test. This test
creates a `MigrationLoader` with the `MIGRATION_MODULES` setting
overridden to empty, causing the loader to search for migrations
files directly. We then run `detect_conflicts()` and assert no
conflicts were returned.
