### PR TITLE
tests: use mocked Git repos where possible (Bug 2037553)

### DIFF
--- a/src/lando/api/tests/test_landings.py
+++ b/src/lando/api/tests/test_landings.py
@@ -1326,21 +1326,38 @@ def test_landing_job_revisions_sorting(
     assert list(job.revisions.all()) == new_ordering
 
 
+@pytest.mark.parametrize(
+    "scm_type,repo_name",
+    [
+        (SCMType.HG, "mozilla-central"),
+        (SCMType.GIT, "firefox"),
+    ],
+)
 @pytest.mark.django_db
 def test_worker_active_repos_updated_when_tree_closed(
+    scm_type,
+    repo_name,
     treestatusdouble,
     monkeypatch,
     get_landing_worker,
 ):
-    repo = Repo.objects.get(name="firefox")
+    repo = Repo.objects.get(name=repo_name)
     treestatusdouble.open_tree(repo.name)
 
-    worker = get_landing_worker(SCMType.GIT)
+    worker = get_landing_worker(scm_type)
     worker.refresh_active_repos()
-    assert repo in worker.active_repos
-    assert repo in worker.enabled_repos
+    assert repo in worker.active_repos, (
+        f"The {scm_type} repo should be active when its tree is open."
+    )
+    assert repo in worker.enabled_repos, (
+        f"The {scm_type} repo should be enabled when its tree is open."
+    )
 
     treestatusdouble.close_tree(repo.name)
     worker.refresh_active_repos()
-    assert repo not in worker.active_repos
-    assert repo in worker.enabled_repos
+    assert repo not in worker.active_repos, (
+        f"The {scm_type} repo should not be active when its tree is closed."
+    )
+    assert repo in worker.enabled_repos, (
+        f"The {scm_type} repo should still be enabled when its tree is closed."
+    )

--- a/src/lando/api/tests/test_landings.py
+++ b/src/lando/api/tests/test_landings.py
@@ -1332,10 +1332,10 @@ def test_worker_active_repos_updated_when_tree_closed(
     monkeypatch,
     get_landing_worker,
 ):
-    repo = Repo.objects.get(name="mozilla-central")
+    repo = Repo.objects.get(name="firefox")
     treestatusdouble.open_tree(repo.name)
 
-    worker = get_landing_worker(SCMType.HG)
+    worker = get_landing_worker(SCMType.GIT)
     worker.refresh_active_repos()
     assert repo in worker.active_repos
     assert repo in worker.enabled_repos

--- a/src/lando/api/tests/test_transplants.py
+++ b/src/lando/api/tests/test_transplants.py
@@ -709,8 +709,13 @@ def test_integrated_transplant_simple_partial_stack_saves_data_in_db(
     assert job.landed_phabricator_revisions == {1: 1, 2: 2}
 
 
+@pytest.mark.parametrize(
+    "scm_type",
+    [SCMType.HG, SCMType.GIT],
+)
 @pytest.mark.django_db
 def test_integrated_transplant_records_approvers_peers_and_owners(
+    scm_type,
     user,
     authenticated_client,
     treestatusdouble,
@@ -721,12 +726,13 @@ def test_integrated_transplant_records_approvers_peers_and_owners(
     normal_patch,
     phabdouble,
     checkin_project,
-    git_landing_worker,
+    get_landing_worker,
     repo_mc,
 ):
-    repo = repo_mc(SCMType.GIT)
+    landing_worker = get_landing_worker(scm_type)
+    repo = repo_mc(scm_type)
     treestatusdouble.open_tree(repo.name)
-    git_landing_worker.worker_instance.applicable_repos.add(repo)
+    landing_worker.worker_instance.applicable_repos.add(repo)
 
     phabrepo = phabdouble.repo(name=repo.name)
     # Mock a few mots-related things needed by the landing worker.
@@ -780,7 +786,7 @@ def test_integrated_transplant_records_approvers_peers_and_owners(
     approved_by = [revision.data["approved_by"] for revision in job.revisions.all()]
     assert approved_by == [[101], [102]]
 
-    assert git_landing_worker.run_job(job)
+    assert landing_worker.run_job(job)
     assert job.landed_commit_id
 
     # Fetch Job data.

--- a/src/lando/api/tests/test_transplants.py
+++ b/src/lando/api/tests/test_transplants.py
@@ -714,8 +714,6 @@ def test_integrated_transplant_records_approvers_peers_and_owners(
     user,
     authenticated_client,
     treestatusdouble,
-    hg_server,
-    hg_clone,
     release_management_project,
     needs_data_classification_project,
     register_codefreeze_uri,
@@ -723,12 +721,12 @@ def test_integrated_transplant_records_approvers_peers_and_owners(
     normal_patch,
     phabdouble,
     checkin_project,
-    hg_landing_worker,
+    git_landing_worker,
     repo_mc,
 ):
-    repo = repo_mc(SCMType.HG)
+    repo = repo_mc(SCMType.GIT)
     treestatusdouble.open_tree(repo.name)
-    hg_landing_worker.worker_instance.applicable_repos.add(repo)
+    git_landing_worker.worker_instance.applicable_repos.add(repo)
 
     phabrepo = phabdouble.repo(name=repo.name)
     # Mock a few mots-related things needed by the landing worker.
@@ -746,11 +744,11 @@ def test_integrated_transplant_records_approvers_peers_and_owners(
     reviewer = phabdouble.user(username="reviewer")
     user2 = phabdouble.user(username="reviewer2")
 
-    d1 = phabdouble.diff(rawdiff=normal_patch(1))
+    d1 = phabdouble.diff(rawdiff=normal_patch(0))
     r1 = phabdouble.revision(diff=d1, repo=phabrepo)
     phabdouble.reviewer(r1, reviewer)
 
-    d2 = phabdouble.diff(rawdiff=normal_patch(2))
+    d2 = phabdouble.diff(rawdiff=normal_patch(1))
     r2 = phabdouble.revision(diff=d2, repo=phabrepo, depends_on=[r1])
     phabdouble.reviewer(r2, user2)
 
@@ -782,7 +780,7 @@ def test_integrated_transplant_records_approvers_peers_and_owners(
     approved_by = [revision.data["approved_by"] for revision in job.revisions.all()]
     assert approved_by == [[101], [102]]
 
-    assert hg_landing_worker.run_job(job)
+    assert git_landing_worker.run_job(job)
     assert job.landed_commit_id
 
     # Fetch Job data.

--- a/src/lando/api/tests/test_worker.py
+++ b/src/lando/api/tests/test_worker.py
@@ -34,8 +34,8 @@ def test_Worker__no_SSH_PRIVATE_KEY(
 
 
 @pytest.fixture
-def mocked_enabled_repos(hg_landing_worker):
-    """Configure `hg_landing_worker` for `run_idle_maintenance` tests.
+def mocked_enabled_repos(git_landing_worker):
+    """Configure `git_landing_worker` for `run_idle_maintenance` tests.
 
     `Worker.enabled_repos` returns a fresh QuerySet on each access, so a mock
     set on `repo._scm` doesn't survive across calls. This fixture freezes the
@@ -46,15 +46,15 @@ def mocked_enabled_repos(hg_landing_worker):
     sleep doesn't slow the test. Individual tests may lower `sleep_seconds`
     to exercise the budget directly.
     """
-    repos = list(hg_landing_worker.enabled_repos)
+    repos = list(git_landing_worker.enabled_repos)
     for repo in repos:
         repo._scm = mock.MagicMock()
-    hg_landing_worker.worker_instance.sleep_seconds = 60
+    git_landing_worker.worker_instance.sleep_seconds = 60
     with (
         mock.patch.object(
-            type(hg_landing_worker), "enabled_repos", new_callable=mock.PropertyMock
+            type(git_landing_worker), "enabled_repos", new_callable=mock.PropertyMock
         ) as mock_enabled,
-        mock.patch.object(hg_landing_worker, "throttle"),
+        mock.patch.object(git_landing_worker, "throttle"),
     ):
         mock_enabled.return_value = repos
         yield repos
@@ -62,10 +62,10 @@ def mocked_enabled_repos(hg_landing_worker):
 
 @pytest.mark.django_db
 def test_Worker_run_idle_maintenance_throttles_repeat_calls(
-    hg_landing_worker, mocked_enabled_repos
+    git_landing_worker, mocked_enabled_repos
 ):
-    hg_landing_worker.run_idle_maintenance()
-    hg_landing_worker.run_idle_maintenance()
+    git_landing_worker.run_idle_maintenance()
+    git_landing_worker.run_idle_maintenance()
 
     for repo in mocked_enabled_repos:
         assert repo._scm.maintenance.call_count == 1, (
@@ -75,18 +75,18 @@ def test_Worker_run_idle_maintenance_throttles_repeat_calls(
 
 @pytest.mark.django_db
 def test_Worker_run_idle_maintenance_runs_again_after_interval(
-    hg_landing_worker, mocked_enabled_repos
+    git_landing_worker, mocked_enabled_repos
 ):
-    hg_landing_worker.run_idle_maintenance()
+    git_landing_worker.run_idle_maintenance()
 
     # Pretend the previous run happened beyond the throttle window.
     interval = timedelta(
-        seconds=hg_landing_worker.worker_instance.maintenance_interval_seconds + 1
+        seconds=git_landing_worker.worker_instance.maintenance_interval_seconds + 1
     )
     for repo in mocked_enabled_repos:
-        hg_landing_worker.last_maintenance_at[repo.id] -= interval
+        git_landing_worker.last_maintenance_at[repo.id] -= interval
 
-    hg_landing_worker.run_idle_maintenance()
+    git_landing_worker.run_idle_maintenance()
 
     for repo in mocked_enabled_repos:
         assert repo._scm.maintenance.call_count == 2, (
@@ -96,26 +96,26 @@ def test_Worker_run_idle_maintenance_runs_again_after_interval(
 
 @pytest.mark.django_db
 def test_Worker_run_idle_maintenance_stops_at_budget_and_prefers_oldest(
-    hg_landing_worker, mocked_enabled_repos
+    git_landing_worker, mocked_enabled_repos
 ):
     """When the time budget is exhausted, stop early after processing the repo
     that has been waiting longest for maintenance."""
     assert len(mocked_enabled_repos) >= 2, "Test requires at least two enabled repos."
 
     # A `sleep_seconds` budget of 0 means we stop after the very first repo.
-    hg_landing_worker.worker_instance.sleep_seconds = 0
+    git_landing_worker.worker_instance.sleep_seconds = 0
 
     # Make every repo eligible (well past the interval) and pin one repo as the oldest.
     interval = timedelta(
-        seconds=hg_landing_worker.worker_instance.maintenance_interval_seconds + 10
+        seconds=git_landing_worker.worker_instance.maintenance_interval_seconds + 10
     )
     now = datetime.now()
     oldest_repo = mocked_enabled_repos[-1]
     for repo in mocked_enabled_repos:
-        hg_landing_worker.last_maintenance_at[repo.id] = now - interval
-    hg_landing_worker.last_maintenance_at[oldest_repo.id] = now - (interval * 2)
+        git_landing_worker.last_maintenance_at[repo.id] = now - interval
+    git_landing_worker.last_maintenance_at[oldest_repo.id] = now - (interval * 2)
 
-    hg_landing_worker.run_idle_maintenance()
+    git_landing_worker.run_idle_maintenance()
 
     assert oldest_repo._scm.maintenance.call_count == 1, (
         "The repo waiting longest should run first when the budget is tight."
@@ -130,20 +130,20 @@ def test_Worker_run_idle_maintenance_stops_at_budget_and_prefers_oldest(
 
 @pytest.mark.django_db
 def test_Worker_run_idle_maintenance_isolates_failures(
-    caplog, hg_landing_worker, mocked_enabled_repos
+    caplog, git_landing_worker, mocked_enabled_repos
 ):
     assert len(mocked_enabled_repos) >= 2, "Test requires at least two enabled repos."
 
     failing_repo, *healthy_repos = mocked_enabled_repos
     failing_repo._scm.maintenance.side_effect = SCMException("boom", "", "")
 
-    hg_landing_worker.run_idle_maintenance()
+    git_landing_worker.run_idle_maintenance()
 
     for repo in healthy_repos:
         repo._scm.maintenance.assert_called_once_with()
     assert f"Idle maintenance failed for {failing_repo.name}" in caplog.text, (
         "A failure in one repo's maintenance should be logged."
     )
-    assert failing_repo.id in hg_landing_worker.last_maintenance_at, (
+    assert failing_repo.id in git_landing_worker.last_maintenance_at, (
         "A failed run should still update the timestamp so we don't retry on every idle loop."
     )

--- a/src/lando/api/tests/test_worker.py
+++ b/src/lando/api/tests/test_worker.py
@@ -34,11 +34,15 @@ def test_Worker__no_SSH_PRIVATE_KEY(
 
 
 @pytest.fixture
-def mocked_enabled_repos(git_landing_worker):
-    """Configure `git_landing_worker` for `run_idle_maintenance` tests.
+def mocked_enabled_repos(get_landing_worker, monkeypatch):
+    """Return a callable that sets up a landing worker for `run_idle_maintenance` tests.
+
+    Call the returned callable with an `SCMType` to get a `(landing_worker, repos)`
+    tuple for that SCM. `monkeypatch` reverts the installed mocks at the end of
+    the test.
 
     `Worker.enabled_repos` returns a fresh QuerySet on each access, so a mock
-    set on `repo._scm` doesn't survive across calls. This fixture freezes the
+    set on `repo._scm` doesn't survive across calls. The callable freezes the
     list once and replaces each repo's lazy SCM with a `MagicMock`.
 
     Also raises `sleep_seconds` so the per-call maintenance time budget isn't
@@ -46,81 +50,91 @@ def mocked_enabled_repos(git_landing_worker):
     sleep doesn't slow the test. Individual tests may lower `sleep_seconds`
     to exercise the budget directly.
     """
-    repos = list(git_landing_worker.enabled_repos)
-    for repo in repos:
-        repo._scm = mock.MagicMock()
-    git_landing_worker.worker_instance.sleep_seconds = 60
-    with (
-        mock.patch.object(
-            type(git_landing_worker), "enabled_repos", new_callable=mock.PropertyMock
-        ) as mock_enabled,
-        mock.patch.object(git_landing_worker, "throttle"),
-    ):
-        mock_enabled.return_value = repos
-        yield repos
+
+    def _setup(scm_type):
+        landing_worker = get_landing_worker(scm_type)
+        repos = list(landing_worker.enabled_repos)
+        for repo in repos:
+            repo._scm = mock.MagicMock()
+        landing_worker.worker_instance.sleep_seconds = 60
+        monkeypatch.setattr(
+            type(landing_worker),
+            "enabled_repos",
+            property(lambda _self: repos),
+        )
+        monkeypatch.setattr(landing_worker, "throttle", mock.MagicMock())
+        return landing_worker, repos
+
+    return _setup
 
 
+@pytest.mark.parametrize("scm_type", [SCMType.HG, SCMType.GIT])
 @pytest.mark.django_db
 def test_Worker_run_idle_maintenance_throttles_repeat_calls(
-    git_landing_worker, mocked_enabled_repos
+    scm_type, mocked_enabled_repos
 ):
-    git_landing_worker.run_idle_maintenance()
-    git_landing_worker.run_idle_maintenance()
+    landing_worker, repos = mocked_enabled_repos(scm_type)
+    landing_worker.run_idle_maintenance()
+    landing_worker.run_idle_maintenance()
 
-    for repo in mocked_enabled_repos:
+    for repo in repos:
         assert repo._scm.maintenance.call_count == 1, (
             "Repeat calls inside `maintenance_interval_seconds` should be throttled."
         )
 
 
+@pytest.mark.parametrize("scm_type", [SCMType.HG, SCMType.GIT])
 @pytest.mark.django_db
 def test_Worker_run_idle_maintenance_runs_again_after_interval(
-    git_landing_worker, mocked_enabled_repos
+    scm_type, mocked_enabled_repos
 ):
-    git_landing_worker.run_idle_maintenance()
+    landing_worker, repos = mocked_enabled_repos(scm_type)
+    landing_worker.run_idle_maintenance()
 
     # Pretend the previous run happened beyond the throttle window.
     interval = timedelta(
-        seconds=git_landing_worker.worker_instance.maintenance_interval_seconds + 1
+        seconds=landing_worker.worker_instance.maintenance_interval_seconds + 1
     )
-    for repo in mocked_enabled_repos:
-        git_landing_worker.last_maintenance_at[repo.id] -= interval
+    for repo in repos:
+        landing_worker.last_maintenance_at[repo.id] -= interval
 
-    git_landing_worker.run_idle_maintenance()
+    landing_worker.run_idle_maintenance()
 
-    for repo in mocked_enabled_repos:
+    for repo in repos:
         assert repo._scm.maintenance.call_count == 2, (
             "`maintenance` should run again once `maintenance_interval_seconds` has elapsed."
         )
 
 
+@pytest.mark.parametrize("scm_type", [SCMType.HG, SCMType.GIT])
 @pytest.mark.django_db
 def test_Worker_run_idle_maintenance_stops_at_budget_and_prefers_oldest(
-    git_landing_worker, mocked_enabled_repos
+    scm_type, mocked_enabled_repos
 ):
     """When the time budget is exhausted, stop early after processing the repo
     that has been waiting longest for maintenance."""
-    assert len(mocked_enabled_repos) >= 2, "Test requires at least two enabled repos."
+    landing_worker, repos = mocked_enabled_repos(scm_type)
+    assert len(repos) >= 2, "Test requires at least two enabled repos."
 
     # A `sleep_seconds` budget of 0 means we stop after the very first repo.
-    git_landing_worker.worker_instance.sleep_seconds = 0
+    landing_worker.worker_instance.sleep_seconds = 0
 
     # Make every repo eligible (well past the interval) and pin one repo as the oldest.
     interval = timedelta(
-        seconds=git_landing_worker.worker_instance.maintenance_interval_seconds + 10
+        seconds=landing_worker.worker_instance.maintenance_interval_seconds + 10
     )
     now = datetime.now()
-    oldest_repo = mocked_enabled_repos[-1]
-    for repo in mocked_enabled_repos:
-        git_landing_worker.last_maintenance_at[repo.id] = now - interval
-    git_landing_worker.last_maintenance_at[oldest_repo.id] = now - (interval * 2)
+    oldest_repo = repos[-1]
+    for repo in repos:
+        landing_worker.last_maintenance_at[repo.id] = now - interval
+    landing_worker.last_maintenance_at[oldest_repo.id] = now - (interval * 2)
 
-    git_landing_worker.run_idle_maintenance()
+    landing_worker.run_idle_maintenance()
 
     assert oldest_repo._scm.maintenance.call_count == 1, (
         "The repo waiting longest should run first when the budget is tight."
     )
-    for repo in mocked_enabled_repos:
+    for repo in repos:
         if repo is oldest_repo:
             continue
         assert repo._scm.maintenance.call_count == 0, (
@@ -128,22 +142,24 @@ def test_Worker_run_idle_maintenance_stops_at_budget_and_prefers_oldest(
         )
 
 
+@pytest.mark.parametrize("scm_type", [SCMType.HG, SCMType.GIT])
 @pytest.mark.django_db
 def test_Worker_run_idle_maintenance_isolates_failures(
-    caplog, git_landing_worker, mocked_enabled_repos
+    caplog, scm_type, mocked_enabled_repos
 ):
-    assert len(mocked_enabled_repos) >= 2, "Test requires at least two enabled repos."
+    landing_worker, repos = mocked_enabled_repos(scm_type)
+    assert len(repos) >= 2, "Test requires at least two enabled repos."
 
-    failing_repo, *healthy_repos = mocked_enabled_repos
+    failing_repo, *healthy_repos = repos
     failing_repo._scm.maintenance.side_effect = SCMException("boom", "", "")
 
-    git_landing_worker.run_idle_maintenance()
+    landing_worker.run_idle_maintenance()
 
     for repo in healthy_repos:
         repo._scm.maintenance.assert_called_once_with()
     assert f"Idle maintenance failed for {failing_repo.name}" in caplog.text, (
         "A failure in one repo's maintenance should be logged."
     )
-    assert failing_repo.id in git_landing_worker.last_maintenance_at, (
+    assert failing_repo.id in landing_worker.last_maintenance_at, (
         "A failed run should still update the timestamp so we don't retry on every idle loop."
     )

--- a/src/lando/conftest.py
+++ b/src/lando/conftest.py
@@ -852,6 +852,37 @@ def mocked_repo_config(mock_repo_config):
         milestone_tracking_flag_template="cf_status_firefox{milestone}",
     )
 
+    # Git versions of the mocked repos.
+    Repo.objects.create(
+        scm_type=SCMType.GIT,
+        name="firefox",
+        url="http://git.test/firefox",
+        required_permission=SCM_LEVEL_3,
+        approval_required=False,
+    )
+    Repo.objects.create(
+        scm_type=SCMType.GIT,
+        name="firefox-uplift",
+        url="http://git.test/firefox-uplift",
+        required_permission=SCM_LEVEL_3,
+        approval_required=True,
+    )
+    Repo.objects.create(
+        scm_type=SCMType.GIT,
+        name="firefox-new",
+        url="http://git.test/firefox-new",
+        required_permission=SCM_LEVEL_3,
+        commit_flags=[("VALIDFLAG1", "testing"), ("VALIDFLAG2", "testing")],
+    )
+    Repo.objects.create(
+        scm_type=SCMType.GIT,
+        name="firefox-uplift-target",
+        url="http://git.test/firefox-uplift-target",
+        required_permission=SCM_LEVEL_1,
+        approval_required=True,
+        milestone_tracking_flag_template="cf_status_firefox{milestone}",
+    )
+
 
 @pytest.fixture
 def mocked_repo_config_try(mock_repo_config):


### PR DESCRIPTION
Add Git repos to `mocked_repo_config`, mirroring the setup
of repos in production. Update tests which were hg-only to
include Git coverage as well.