### PR TITLE
main.models: implement CryptographyMixin (bug 2042216)

### DIFF
--- a/src/lando/conftest.py
+++ b/src/lando/conftest.py
@@ -1273,7 +1273,7 @@ def user(
 ) -> User:
     """A User with all SCM permissions levels."""
     user = scm_user(conduit_permissions, user_plaintext_password)
-    user.profile.save_phabricator_api_key(user_phab_api_key)
+    user.profile.set_phabricator_api_key(user_phab_api_key)
 
     user.save()
     user.profile.save()

--- a/src/lando/main/models/base.py
+++ b/src/lando/main/models/base.py
@@ -1,7 +1,10 @@
 import logging
 from contextlib import ContextDecorator
+from typing import Callable
 
 from django.db import connection, models, transaction
+
+from lando.utils.crypto import ENCRYPTED_FIELD_PREFIX, FUNC_PREFIXES, cryptography
 
 logger = logging.getLogger(__name__)
 
@@ -25,6 +28,106 @@ class LockTableContextManager(ContextDecorator):
 
     def __exit__(self, exc_type, exc_value, traceback):  # noqa: ANN001
         pass
+
+
+class CryptographyMixin:
+    """
+    Provide a more convenient way of encrypting and decrypting fields.
+
+    String-based fields that are prefixed with `encrypted_` will have this feature enabled.
+    For example, a field such as MyModel.encrypted_secret_name will provide the following:
+    - MyModel.secret_name: The decrypted value of MyModel.encrypted_secret_name
+    - MyModel.set_secret_name: Encrypt and set the value of MyModel.encrypted_secret_name
+    - MyModel.clear_secret_name: Clear and encrypt the value of MyModel.encrypted_secret_name
+    - MyModel.rotate_secret_name: Use when rotating the secret keys used to encrypt values.
+    """
+
+    def __getattr__(self, name: str) -> object:
+        """Redirect to appropriate function call."""
+        obj_dir = object.__dir__(self)
+        encrypted_fields = tuple(
+            field.removeprefix(ENCRYPTED_FIELD_PREFIX)
+            for field in obj_dir
+            if field.startswith(ENCRYPTED_FIELD_PREFIX)
+        )
+        crypto_methods = [
+            f"{prefix}{field_name}"
+            for prefix in FUNC_PREFIXES
+            for field_name in encrypted_fields
+        ]
+
+        if name in crypto_methods:
+            method, field_name = name.split("_", 1)
+            return object.__getattribute__(self, f"get_{method}_encrypted_field")(
+                field_name
+            )
+
+        if f"{ENCRYPTED_FIELD_PREFIX}{name}" in obj_dir:
+            # The request is for the decrypted value of the field.
+            return self._get_decrypted_value_or_empty(name)
+
+        return object.__getattribute__(self, name)
+
+    def _get_decrypted_value_or_empty(self, field_name: str) -> str:
+        """Return decrypted value, or an empty string if there is no value."""
+        encrypted_value = bytes(getattr(self, f"{ENCRYPTED_FIELD_PREFIX}{field_name}"))
+        if encrypted_value:
+            return self._decrypt_value(encrypted_value)
+        else:
+            return ""
+
+    def _encrypt_value(self, value: str) -> bytes:
+        """Encrypt a given string value."""
+        return cryptography.encrypt(value.encode("utf-8"))
+
+    def _decrypt_value(self, value: bytes) -> str:
+        """Decrypt a given bytes value."""
+        return cryptography.decrypt(value).decode("utf-8")
+
+    def _rotate_value(self, value: bytes) -> bytes:
+        """Return a rotated encrypted bytes value."""
+        return cryptography.rotate(value)
+
+    def get_clear_encrypted_field(self, field_name: str) -> Callable:
+        """Return the corresponding method to clear the encrypted field."""
+        set_encrypted_field = self.get_set_encrypted_field(field_name)
+
+        def clear_encrypted_field(save: bool = True):
+            """Set value to encrypted blank string."""
+            set_encrypted_field("", save=save)
+
+        return clear_encrypted_field
+
+    def get_set_encrypted_field(self, field_name: str) -> Callable:
+        """Return the corresponding method to set the encrypted field."""
+
+        def set_encrypted_field(value: str, save: bool = True):
+            """Set encrypted value to given field and save if needed."""
+            setattr(
+                self,
+                f"{ENCRYPTED_FIELD_PREFIX}{field_name}",
+                self._encrypt_value(value),
+            )
+            if save:
+                self.save()
+
+        return set_encrypted_field
+
+    def get_rotate_encrypted_field(self, field_name: str) -> Callable:
+        """Return the corresponding method to rotate the encrypted field."""
+
+        def rotate_encrypted_field():
+            """Rotate encryption on given field."""
+            setattr(
+                self,
+                f"{ENCRYPTED_FIELD_PREFIX}{field_name}",
+                self._rotate_value(
+                    bytes(getattr(self, f"{ENCRYPTED_FIELD_PREFIX}{field_name}"))
+                ),
+            )
+            self.save()
+
+        return rotate_encrypted_field
 
 
 class BaseModel(models.Model):

--- a/src/lando/main/models/profile.py
+++ b/src/lando/main/models/profile.py
@@ -1,10 +1,9 @@
-from cryptography.fernet import Fernet, MultiFernet
 from django.conf import settings
 from django.contrib.auth.models import Permission, User
 from django.contrib.contenttypes.models import ContentType
-from django.db import models
+from django.db import models, transaction
 
-from lando.main.models.base import BaseModel
+from lando.main.models.base import BaseModel, CryptographyMixin
 
 SCM_PERMISSIONS = (
     ("scm_allow_direct_push", "SCM_ALLOW_DIRECT_PUSH"),
@@ -62,16 +61,13 @@ def filter_claims(claims: dict) -> dict:
     return claims
 
 
-class Profile(BaseModel):
+class Profile(CryptographyMixin, BaseModel):
     """A model to store additional information about users."""
 
     class Meta:
         permissions = SCM_PERMISSIONS + (
             ("can_view_private_repos", "CAN_VIEW_PRIVATE_REPOS"),
         )
-
-    # Provide encryption/decryption functionality.
-    cryptography = MultiFernet([Fernet(key) for key in settings.ENCRYPTION_KEYS])
 
     user = models.OneToOneField(User, null=True, on_delete=models.SET_NULL)
 
@@ -86,18 +82,6 @@ class Profile(BaseModel):
     phabricator_phid = models.CharField(
         max_length=255, null=True, blank=True, unique=True
     )
-
-    def _encrypt_value(self, value: str) -> bytes:
-        """Encrypt a given string value."""
-        return self.cryptography.encrypt(value.encode("utf-8"))
-
-    def _decrypt_value(self, value: bytes) -> str:
-        """Decrypt a given bytes value."""
-        return self.cryptography.decrypt(value).decode("utf-8")
-
-    def _rotate_value(self, value: bytes) -> bytes:
-        """Return a rotated encrypted bytes value."""
-        return self.cryptography.rotate(value)
 
     def _has_scm_permission_groups(self, codename: str, groups: list[str]) -> bool:
         """Return whether the group membership provides the correct permission.
@@ -123,30 +107,19 @@ class Profile(BaseModel):
 
         return permissions
 
-    @property
-    def phabricator_api_key(self) -> str:
-        """Decrypt and return the value of the Phabricator API key."""
-        encrypted_key = bytes(self.encrypted_phabricator_api_key)
-        if encrypted_key:
-            return self._decrypt_value(encrypted_key)
-        else:
-            return ""
-
-    def clear_phabricator_api_key(self):
+    def clear_phabricator_elements(self):
         """Clear the phabricator API key and PHID."""
-        self.save_phabricator_api_key("", phid=None)
+        with transaction.atomic():
+            self.clear_phabricator_api_key(save=False)
+            self.phabricator_phid = None
+            self.save()
 
-    def save_phabricator_api_key(self, key: str, phid: str | None = None):
+    def save_phabricator_elements(self, key: str, phid: str | None = None):
         """Given a raw API key and PHID, encrypt the key and store both."""
-        self.encrypted_phabricator_api_key = self._encrypt_value(key)
-        self.phabricator_phid = phid or None
-        self.save()
-
-    def rotate_phabricator_api_key_encryption(self):
-        self.encrypted_phabricator_api_key = self._rotate_value(
-            bytes(self.encrypted_phabricator_api_key)
-        )
-        self.save()
+        with transaction.atomic():
+            self.set_phabricator_api_key(key, save=False)
+            self.phabricator_phid = phid or None
+            self.save()
 
     def update_permissions(self):
         """Remove SCM permissions and re-add them based on userinfo."""

--- a/src/lando/main/tests/__init__.py
+++ b/src/lando/main/tests/__init__.py
@@ -1,4 +1,3 @@
-import base64
 from unittest.mock import MagicMock
 
 import pytest
@@ -6,7 +5,7 @@ from django.contrib.auth.models import User
 from django.http import HttpResponse
 
 from lando.main.auth import LandoOIDCAuthenticationBackend, require_phabricator_api_key
-from lando.main.models.profile import CLAIM_GROUPS_KEY, Profile
+from lando.main.models.profile import CLAIM_GROUPS_KEY
 from lando.utils.phabricator import PhabricatorClient
 
 
@@ -83,22 +82,3 @@ def test_require_phabricator_api_key(monkeypatch, optional, valid_key, status):
         assert resp.body.api_token == "custom-key"
 
     assert resp.status_code == status
-
-
-@pytest.mark.django_db(transaction=True)
-def test_phabricator_api_key_encryption():
-    user = User.objects.create_user(username="test_user", password="test_password")
-    profile = Profile.objects.create(user=user)
-
-    assert profile.phabricator_api_key == ""
-
-    # Set an arbitrary key.
-    key = "test-key"
-    profile.save_phabricator_api_key(key)
-    assert key.encode("utf-8") not in profile.encrypted_phabricator_api_key
-    assert base64.b64decode(profile.encrypted_phabricator_api_key)
-    assert profile.phabricator_api_key == key
-
-    # Clear the key
-    profile.clear_phabricator_api_key()
-    assert profile.phabricator_api_key == ""

--- a/src/lando/main/tests/test_models.py
+++ b/src/lando/main/tests/test_models.py
@@ -10,6 +10,8 @@ from django.contrib.auth.models import Permission, User
 from django.core.exceptions import ValidationError
 
 from lando.main.models import CommitMap, Repo
+from lando.main.models.base import CryptographyMixin
+from lando.main.models.profile import Profile
 from lando.main.models.repo import (
     get_default_autoformat_run_command,
     get_default_autoformat_setup_commands,
@@ -30,6 +32,15 @@ diff --git a/test.txt b/test.txt
  TEST
 +adding another line
 """.lstrip()
+
+
+@pytest.fixture
+def mock_crypto_model():
+    class MockModel(CryptographyMixin):
+        save = MagicMock()
+        arbitrary_field = MagicMock()
+
+    return MockModel()
 
 
 @pytest.mark.parametrize(
@@ -536,3 +547,80 @@ def test_hook_choices_all_checks():
         assert hook.label == check_dict[hook.name], (
             f"Hook choice label doesn't match check description for {hook.name}"
         )
+
+
+@pytest.mark.django_db(transaction=True)
+def test_phabricator_api_key_encryption():
+    user = User.objects.create_user(username="test_user", password="test_password")
+    profile = Profile.objects.create(user=user)
+
+    assert profile.phabricator_api_key == ""
+
+    # Set an arbitrary key.
+    key = "test-key"
+    profile.set_phabricator_api_key(key)
+    assert key.encode("utf-8") not in profile.encrypted_phabricator_api_key
+    assert profile.phabricator_api_key == key
+
+    # Clear the key
+    profile.clear_phabricator_api_key()
+    assert profile.phabricator_api_key == ""
+
+
+@mock.patch("lando.main.models.base.cryptography")
+def test_cryptography_mixin__set_field(cryptography, mock_crypto_model):
+    mock_crypto_model.encrypted_made_up_field = None
+    mock_crypto_model.set_made_up_field("this is a test")
+    assert cryptography.encrypt.call_count == 1
+    assert cryptography.encrypt.call_args[0] == (b"this is a test",)
+    assert mock_crypto_model.save.call_count == 1
+
+
+@mock.patch("lando.main.models.base.cryptography")
+def test_cryptography_mixin__set_field_do_not_save(cryptography, mock_crypto_model):
+    mock_crypto_model.encrypted_made_up_field = None
+    mock_crypto_model.set_made_up_field("this is a test", save=False)
+    assert cryptography.encrypt.call_count == 1
+    assert cryptography.encrypt.call_args[0] == (b"this is a test",)
+    assert mock_crypto_model.save.call_count == 0
+
+
+@mock.patch("lando.main.models.base.cryptography")
+def test_cryptography_mixin__clear_field(cryptography, mock_crypto_model):
+    mock_crypto_model.encrypted_made_up_field = None
+    mock_crypto_model.clear_made_up_field()
+    assert cryptography.encrypt.call_count == 1
+    assert cryptography.encrypt.call_args[0] == (b"",)
+    assert mock_crypto_model.save.call_count == 1
+
+
+@mock.patch("lando.main.models.base.cryptography")
+def test_cryptography_mixin__rotate_field(cryptography, mock_crypto_model):
+    mock_crypto_model.encrypted_made_up_field = None
+    cryptography.encrypt.return_value = b"something encrypted"
+    mock_crypto_model.set_made_up_field("this is a test")
+    assert cryptography.encrypt.call_args[0] == (b"this is a test",)
+    assert mock_crypto_model.save.call_count == 1
+
+    mock_crypto_model.rotate_made_up_field()
+    assert cryptography.rotate.call_count == 1
+    assert cryptography.rotate.call_args[0] == (b"something encrypted",)
+    assert mock_crypto_model.save.call_count == 2
+
+
+def test_cryptography_mixin____getattr__(mock_crypto_model):
+    # Test that a non-existent attribute raises AttributeError.
+    with pytest.raises(AttributeError) as e:
+        mock_crypto_model.some_nonexistent_field  # noqa: B018 (unused not useless)
+    assert e.value.args[0].endswith("object has no attribute 'some_nonexistent_field'")
+
+    # Test that an arbitrary field with an encrypted equivalent falls back
+    # to concrete field.
+    original_field_id = id(mock_crypto_model.arbitrary_field)
+    mock_crypto_model.encrypted_arbitrary_field = ""
+    assert id(mock_crypto_model.arbitrary_field) == original_field_id
+
+    # Test some standard attributes on the mixin to ensure __getattr__ does not
+    # cause unexpected problems.
+    assert mock_crypto_model.__class__.__name__ == "MockModel"
+    assert mock_crypto_model.__dir__() == object.__dir__(mock_crypto_model)

--- a/src/lando/ui/legacy/user_settings.py
+++ b/src/lando/ui/legacy/user_settings.py
@@ -47,7 +47,7 @@ def manage_api_key(request: WSGIRequest) -> JsonResponse:
 
     profile = request.user.profile
     if form.cleaned_data["reset_key"]:
-        profile.clear_phabricator_api_key()
+        profile.clear_phabricator_elements()
     else:
         api_key = form.cleaned_data["phabricator_api_key"]
 
@@ -71,7 +71,7 @@ def manage_api_key(request: WSGIRequest) -> JsonResponse:
             return phid_conflict_response(phid)
 
         try:
-            profile.save_phabricator_api_key(api_key, phid=phid)
+            profile.save_phabricator_elements(api_key, phid=phid)
         except IntegrityError:
             return phid_conflict_response(phid)
 

--- a/src/lando/utils/crypto.py
+++ b/src/lando/utils/crypto.py
@@ -1,0 +1,15 @@
+from cryptography.fernet import Fernet, MultiFernet
+from django.conf import settings
+
+ENCRYPTED_FIELD_PREFIX = "encrypted_"
+CLEAR_FIELD_PREFIX = "clear_"
+SET_FIELD_PREFIX = "set_"
+ROTATE_FIELD_PREFIX = "rotate_"
+FUNC_PREFIXES = (
+    CLEAR_FIELD_PREFIX,
+    SET_FIELD_PREFIX,
+    ROTATE_FIELD_PREFIX,
+)
+
+# Provide encryption/decryption functionality.
+cryptography = MultiFernet([Fernet(key) for key in settings.ENCRYPTION_KEYS])


### PR DESCRIPTION
- add CryptographyMixin to provide helpers to facilitate encrypted fields
- adding this mixin provides setters/getters for fields beginning with `encrypted_`
- also addresses bug 2042218