### PR TITLE
make: rename `upgrade-npm` to `upgrade-npm-packages` (Bug 2042577)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,8 +59,8 @@ upgrade-requirements:
 add-requirements:
 	$(BASE_COMMAND) lando generate_requirements
 
-.PHONY: upgrade-npm
-upgrade-npm:
+.PHONY: upgrade-npm-packages
+upgrade-npm-packages:
 	$(BASE_COMMAND) npm install
 
 .PHONY: attach


### PR DESCRIPTION
`upgrade-npm-packages` was the intended name. I updated the value
in the help text, but forgot to update the actual definition
in the Makefile.
