### PR TITLE
Makefile: add `build` target and self-documenting logic (bug 2042614)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Build
-        run: docker build -t lando .
+        run: make build
       - name: Test
         run: make test-py
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Build
-        run: make build
+        run: docker build -t lando .
       - name: Test
         run: make test-py
 

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ else
 	BASE_COMMAND := ${DOCKER_COMPOSE} run --rm lando
 endif
 
+# This target needs to be the first in the file, so it's called by default.
 .PHONY: help
 help:
 	@$(DOCKER) --version
@@ -20,41 +21,35 @@ help:
 	@echo "usage: make <target>"
 	@echo
 	@echo "target is one of:"
-	@echo "    help                 show this message and exit"
+	@echo "    add-requirements     update requirements.txt with new requirements"
+	@echo "    attach               attach for debugging (ctrl-p ctrl-q to detach)"
+	@echo "    build                build the container images"
 	@echo "    format               run ruff and djLint on source code"
+	@echo "    help                 show this message and exit"
+	@echo "    migrations           generates migration files to reflect model changes in the database"
 	@echo "    test                 run the Python and JavaScript test suites"
 	@echo "    test-py              run the Python test suite"
 	@echo "    test-js              run the JavaScript test suite (Vitest)"
-	@echo "    migrations           generates migration files to reflect model changes in the database"
-	@echo "    upgrade-requirements upgrade packages in requirements.txt"
-	@echo "    upgrade-npm-packages update package-lock.json"
-	@echo "    add-requirements     update requirements.txt with new requirements"
-	@echo "    attach               attach for debugging (ctrl-p ctrl-q to detach)"
-	@echo "    test-use-suite       run the testsuite using the conduit-suite environment"
 	@echo "    test-use-local       run the testsuite using the local environment"
+	@echo "    test-use-suite       run the testsuite using the conduit-suite environment"
+	@echo "    upgrade-npm-packages update package-lock.json"
+	@echo "    upgrade-requirements upgrade packages in requirements.txt"
+
+.PHONY: add-requirements
+add-requirements:
+	$(BASE_COMMAND) lando generate_requirements
+
+.PHONY: attach
+attach:
+ifeq ($(INSUITE), 1)
+	-@docker attach suite-lando-1 ||:
+else
+	-@${DOCKER_COMPOSE} attach lando ||:
+endif
 
 .PHONY: build
 build:
 	$(DOCKER_COMPOSE) build
-
-.PHONY: test
-test: test-py test-js
-
-.PHONY: test-py
-test-py:
-	$(BASE_COMMAND) lando tests $(ARGS_TESTS)
-
-.PHONY: test-js
-test-js:
-	$(BASE_COMMAND) npm test
-
-.PHONY: test-use-suite
-test-use-suite:
-	echo 1 > ${SUITE_STAMP}
-
-.PHONY: test-use-local
-test-use-local:
-	rm -f ${SUITE_STAMP}
 
 .PHONY: format
 format:
@@ -64,22 +59,29 @@ format:
 migrations:
 	$(BASE_COMMAND) lando makemigrations
 
-.PHONY: upgrade-requirements
-upgrade-requirements:
-	$(BASE_COMMAND) lando generate_requirements --upgrade
+.PHONY: test
+test: test-py test-js
 
-.PHONY: add-requirements
-add-requirements:
-	$(BASE_COMMAND) lando generate_requirements
+.PHONY: test-js
+test-js:
+	$(BASE_COMMAND) npm test
+
+.PHONY: test-py
+test-py:
+	$(BASE_COMMAND) lando tests $(ARGS_TESTS)
+
+.PHONY: test-use-local
+test-use-local:
+	rm -f ${SUITE_STAMP}
+
+.PHONY: test-use-suite
+test-use-suite:
+	echo 1 > ${SUITE_STAMP}
 
 .PHONY: upgrade-npm-packages
 upgrade-npm-packages:
 	$(BASE_COMMAND) npm install
 
-.PHONY: attach
-attach:
-ifeq ($(INSUITE), 1)
-	-@docker attach suite-lando-1 ||:
-else
-	-@${DOCKER_COMPOSE} attach lando ||:
-endif
+.PHONY: upgrade-requirements
+upgrade-requirements:
+	$(BASE_COMMAND) lando generate_requirements --upgrade

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,10 @@ help:
 	@echo "    test-use-suite       run the testsuite using the conduit-suite environment"
 	@echo "    test-use-local       run the testsuite using the local environment"
 
+.PHONY: build
+build:
+	$(DOCKER_COMPOSE) build
+
 .PHONY: test
 test: test-py test-js
 

--- a/Makefile
+++ b/Makefile
@@ -14,33 +14,23 @@ else
 endif
 
 # This target needs to be the first in the file, so it's called by default.
+# Any target with an inline comment introduced with `##` will be shown here.
+# Keeping `##` markers aligned in this file will ensure the output is aligned, too.
 .PHONY: help
-help:
+help:                 ## show this message and exit
 	@$(DOCKER) --version
 	@$(DOCKER_COMPOSE) version
 	@echo "usage: make <target>"
 	@echo
 	@echo "target is one of:"
-	@echo "    add-requirements     update requirements.txt with new requirements"
-	@echo "    attach               attach for debugging (ctrl-p ctrl-q to detach)"
-	@echo "    build                build the container images"
-	@echo "    format               run ruff and djLint on source code"
-	@echo "    help                 show this message and exit"
-	@echo "    migrations           generates migration files to reflect model changes in the database"
-	@echo "    test                 run the Python and JavaScript test suites"
-	@echo "    test-py              run the Python test suite"
-	@echo "    test-js              run the JavaScript test suite (Vitest)"
-	@echo "    test-use-local       run the testsuite using the local environment"
-	@echo "    test-use-suite       run the testsuite using the conduit-suite environment"
-	@echo "    upgrade-npm-packages update package-lock.json"
-	@echo "    upgrade-requirements upgrade packages in requirements.txt"
+	@sed -n 's/\(^[^	:]*\+\):\(\s*\)## \(.*\)$$/    \1\2\3/p' Makefile
 
 .PHONY: add-requirements
-add-requirements:
+add-requirements:     ## add-requirements
 	$(BASE_COMMAND) lando generate_requirements
 
 .PHONY: attach
-attach:
+attach:               ## attach for debugging (ctrl-p ctrl-q to detach)
 ifeq ($(INSUITE), 1)
 	-@docker attach suite-lando-1 ||:
 else
@@ -48,40 +38,40 @@ else
 endif
 
 .PHONY: build
-build:
+build:                ## build the container images
 	$(DOCKER_COMPOSE) build
 
 .PHONY: format
-format:
+format:               ## run ruff and djLint on source code
 	$(BASE_COMMAND) lando format
-
 .PHONY: migrations
-migrations:
+migrations:           ## generates migration files to reflect model changes in the database
 	$(BASE_COMMAND) lando makemigrations
 
 .PHONY: test
+test:                 ## run the Python and JavaScript test suites
 test: test-py test-js
 
 .PHONY: test-js
-test-js:
+test-js:              ## run the JavaScript test suite (Vitest)"
 	$(BASE_COMMAND) npm test
 
 .PHONY: test-py
-test-py:
+test-py:              ##run the Python test suite"
 	$(BASE_COMMAND) lando tests $(ARGS_TESTS)
 
 .PHONY: test-use-local
-test-use-local:
+test-use-local:       ## run the testsuite using the local environment
 	rm -f ${SUITE_STAMP}
 
 .PHONY: test-use-suite
-test-use-suite:
+test-use-suite:       ## run the testsuite using the conduit-suite environment
 	echo 1 > ${SUITE_STAMP}
 
 .PHONY: upgrade-npm-packages
-upgrade-npm-packages:
+upgrade-npm-packages: ## upgrade-npm-packages update package-lock.json
 	$(BASE_COMMAND) npm install
 
 .PHONY: upgrade-requirements
-upgrade-requirements:
+upgrade-requirements: ## upgrade-requirements upgrade packages in requirements.txt
 	$(BASE_COMMAND) lando generate_requirements --upgrade

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ endif
 # Any target with an inline comment introduced with `##` will be shown here.
 # Keeping `##` markers aligned in this file will ensure the output is aligned, too.
 .PHONY: help
-help:                 ## show this message and exit
+help: ## show this message and exit
 	@$(DOCKER) --version
 	@$(DOCKER_COMPOSE) version
 	@echo "usage: make <target>"
@@ -26,11 +26,11 @@ help:                 ## show this message and exit
 	@sed -n 's/\(^[^	:]*\+\):\s*##\s*\(.*\)$$/    :\1:\2/p' Makefile | column --table --separator :
 
 .PHONY: add-requirements
-add-requirements:     ## add-requirements
+add-requirements: ## add-requirements
 	$(BASE_COMMAND) lando generate_requirements
 
 .PHONY: attach
-attach:               ## attach for debugging (ctrl-p ctrl-q to detach)
+attach: ## attach for debugging (ctrl-p ctrl-q to detach)
 ifeq ($(INSUITE), 1)
 	-@docker attach suite-lando-1 ||:
 else
@@ -38,34 +38,34 @@ else
 endif
 
 .PHONY: build
-build:                ## build the container images
+build: ## build the container images
 	$(DOCKER_COMPOSE) build
 
 .PHONY: format
-format:               ## run ruff and djLint on source code
+format: ## run ruff and djLint on source code
 	$(BASE_COMMAND) lando format
 .PHONY: migrations
-migrations:           ## generates migration files to reflect model changes in the database
+migrations: ## generates migration files to reflect model changes in the database
 	$(BASE_COMMAND) lando makemigrations
 
 .PHONY: test
-test:                 ## run the Python and JavaScript test suites
+test: ## run the Python and JavaScript test suites
 test: test-py test-js
 
 .PHONY: test-js
-test-js:              ## run the JavaScript test suite (Vitest)
+test-js: ## run the JavaScript test suite (Vitest)
 	$(BASE_COMMAND) npm test
 
 .PHONY: test-py
-test-py:              ##run the Python test suite
+test-py: ##run the Python test suite
 	$(BASE_COMMAND) lando tests $(ARGS_TESTS)
 
 .PHONY: test-use-local
-test-use-local:       ## run the testsuite using the local environment
+test-use-local: ## run the testsuite using the local environment
 	rm -f ${SUITE_STAMP}
 
 .PHONY: test-use-suite
-test-use-suite:       ## run the testsuite using the conduit-suite environment
+test-use-suite: ## run the testsuite using the conduit-suite environment
 	echo 1 > ${SUITE_STAMP}
 
 .PHONY: upgrade-npm-packages

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ help: ## show this message and exit
 	@sed -n 's/\(^[^	:]*\+\):\s*##\s*\(.*\)$$/    :\1:\2/p' Makefile | column --table --separator :
 
 .PHONY: add-requirements
-add-requirements: ## add-requirements
+add-requirements: ## update requirements.txt with new requirements
 	$(BASE_COMMAND) lando generate_requirements
 
 .PHONY: attach

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ help:                 ## show this message and exit
 	@echo "usage: make <target>"
 	@echo
 	@echo "target is one of:"
-	@sed -n 's/\(^[^	:]*\+\):\(\s*\)##\s*\(.*\)$$/    \1\2\3/p' Makefile
+	@sed -n 's/\(^[^	:]*\+\):\s*##\s*\(.*\)$$/    :\1:\2/p' Makefile | column --table --separator :
 
 .PHONY: add-requirements
 add-requirements:     ## add-requirements

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ help:                 ## show this message and exit
 	@echo "usage: make <target>"
 	@echo
 	@echo "target is one of:"
-	@sed -n 's/\(^[^	:]*\+\):\(\s*\)## \(.*\)$$/    \1\2\3/p' Makefile
+	@sed -n 's/\(^[^	:]*\+\):\(\s*\)##\s*\(.*\)$$/    \1\2\3/p' Makefile
 
 .PHONY: add-requirements
 add-requirements:     ## add-requirements
@@ -53,11 +53,11 @@ test:                 ## run the Python and JavaScript test suites
 test: test-py test-js
 
 .PHONY: test-js
-test-js:              ## run the JavaScript test suite (Vitest)"
+test-js:              ## run the JavaScript test suite (Vitest)
 	$(BASE_COMMAND) npm test
 
 .PHONY: test-py
-test-py:              ##run the Python test suite"
+test-py:              ##run the Python test suite
 	$(BASE_COMMAND) lando tests $(ARGS_TESTS)
 
 .PHONY: test-use-local


### PR DESCRIPTION
 * Makefile: add build target
 * Makefile: sort targets lexicographically
 * Makefile: self-documenting Makefile
    The `help` target auto-generates an entry for each target with an inline comment introduced by a `##`.
 * Makefile: use column(1) to dynamically tabulate the help