### PR TITLE
navbar: render admin button when user is a Conduit admin (Bug 2042232)

### DIFF
--- a/src/lando/jinja.py
+++ b/src/lando/jinja.py
@@ -11,10 +11,10 @@ from django.utils.html import escape
 from jinja2 import Environment
 from markupsafe import Markup
 
+from lando.main.auth import user_is_conduit_admin
 from lando.main.models import JobStatus, LandingJob, Repo, UpliftJob
 from lando.main.models.revision import Revision
 from lando.main.scm import SCMType
-from lando.middleware import user_is_conduit_admin
 from lando.treestatus.models import (
     ReasonCategory,
     TreeCategory,

--- a/src/lando/jinja.py
+++ b/src/lando/jinja.py
@@ -14,6 +14,7 @@ from markupsafe import Markup
 from lando.main.models import JobStatus, LandingJob, Repo, UpliftJob
 from lando.main.models.revision import Revision
 from lando.main.scm import SCMType
+from lando.middleware import user_is_conduit_admin
 from lando.treestatus.models import (
     ReasonCategory,
     TreeCategory,
@@ -462,6 +463,7 @@ def environment(**options) -> Environment:
             "new_settings_form": UserSettingsForm,
             "static_url": settings.STATIC_URL,
             "url": reverse,
+            "user_is_conduit_admin": user_is_conduit_admin,
         }
     )
     env.filters.update(

--- a/src/lando/main/auth.py
+++ b/src/lando/main/auth.py
@@ -20,6 +20,20 @@ from lando.utils.phabricator import PhabricatorClient
 
 logger = logging.getLogger(__name__)
 
+CONDUIT_ADMIN_GROUP_NAME = "conduit-admin"
+
+
+def user_is_conduit_admin(user: User) -> bool:
+    """Return whether `user` is a Conduit administrator.
+
+    Administrators are staff users who belong to the `conduit-admin` group.
+    """
+    return (
+        user.is_authenticated
+        and user.is_staff
+        and user.groups.filter(name=CONDUIT_ADMIN_GROUP_NAME).exists()
+    )
+
 
 class PhabricatorTokenAuthenticationBackend(BaseBackend):
     """Authenticate a user based on their Phabricator PHID and token."""

--- a/src/lando/main/tests/test_auth.py
+++ b/src/lando/main/tests/test_auth.py
@@ -1,0 +1,33 @@
+import pytest
+from django.contrib.auth.models import AnonymousUser, Group, User
+
+from lando.main.auth import CONDUIT_ADMIN_GROUP_NAME, user_is_conduit_admin
+
+
+@pytest.mark.parametrize(
+    "is_staff,in_group,expected",
+    (
+        (True, True, True),
+        (True, False, False),
+        (False, True, False),
+        (False, False, False),
+    ),
+)
+@pytest.mark.django_db
+def test_user_is_conduit_admin(is_staff: bool, in_group: bool, expected: bool):
+    user = User.objects.create_user("testuser", is_staff=is_staff)
+    if in_group:
+        group, _ = Group.objects.get_or_create(name=CONDUIT_ADMIN_GROUP_NAME)
+        group.user_set.add(user)
+
+    assert user_is_conduit_admin(user) is expected, (
+        f"A staff={is_staff}, in_group={in_group} user should "
+        f"{'' if expected else 'not '}be a Conduit admin."
+    )
+
+
+@pytest.mark.django_db
+def test_user_is_conduit_admin_anonymous():
+    assert user_is_conduit_admin(AnonymousUser()) is False, (
+        "An unauthenticated user should not be a Conduit admin."
+    )

--- a/src/lando/middleware.py
+++ b/src/lando/middleware.py
@@ -7,13 +7,13 @@ from typing import Optional
 
 from django.conf import settings
 from django.contrib.auth import authenticate
-from django.contrib.auth.models import User
 from django.core.handlers.wsgi import WSGIRequest
 from django.http import HttpRequest, HttpResponse
 from django.template.loader import render_to_string
 from django.template.response import TemplateResponse
 from django.urls import resolve
 
+from lando.main.auth import user_is_conduit_admin
 from lando.main.models import ConfigurationKey, ConfigurationVariable
 from lando.utils.phabricator import (
     PhabricatorAPIException,
@@ -21,20 +21,6 @@ from lando.utils.phabricator import (
 )
 
 logger = logging.getLogger(__name__)
-
-CONDUIT_ADMIN_GROUP_NAME = "conduit-admin"
-
-
-def user_is_conduit_admin(user: User) -> bool:
-    """Return whether `user` is a Conduit administrator.
-
-    Administrators are staff users who belong to the `conduit-admin` group.
-    """
-    return (
-        user.is_authenticated
-        and user.is_staff
-        and user.groups.filter(name=CONDUIT_ADMIN_GROUP_NAME).exists()
-    )
 
 
 class ResponseHeadersMiddleware:

--- a/src/lando/middleware.py
+++ b/src/lando/middleware.py
@@ -7,6 +7,7 @@ from typing import Optional
 
 from django.conf import settings
 from django.contrib.auth import authenticate
+from django.contrib.auth.models import User
 from django.core.handlers.wsgi import WSGIRequest
 from django.http import HttpRequest, HttpResponse
 from django.template.loader import render_to_string
@@ -22,6 +23,18 @@ from lando.utils.phabricator import (
 logger = logging.getLogger(__name__)
 
 CONDUIT_ADMIN_GROUP_NAME = "conduit-admin"
+
+
+def user_is_conduit_admin(user: User) -> bool:
+    """Return whether `user` is a Conduit administrator.
+
+    Administrators are staff users who belong to the `conduit-admin` group.
+    """
+    return (
+        user.is_authenticated
+        and user.is_staff
+        and user.groups.filter(name=CONDUIT_ADMIN_GROUP_NAME).exists()
+    )
 
 
 class ResponseHeadersMiddleware:
@@ -78,11 +91,7 @@ class MaintenanceModeMiddleware:
         self.get_response = get_response
 
     def __call__(self, request: WSGIRequest) -> HttpResponse:
-        if (
-            request.user.is_authenticated
-            and request.user.is_staff
-            and request.user.groups.filter(name=CONDUIT_ADMIN_GROUP_NAME).exists()
-        ):
+        if user_is_conduit_admin(request.user):
             return self.get_response(request)
 
         excepted_namespaces = (

--- a/src/lando/tests/test_middlewares.py
+++ b/src/lando/tests/test_middlewares.py
@@ -1,8 +1,5 @@
 import pytest
-from django.contrib.auth.models import AnonymousUser, Group, User
 from django.test.client import Client
-
-from lando.middleware import CONDUIT_ADMIN_GROUP_NAME, user_is_conduit_admin
 
 
 @pytest.mark.parametrize(
@@ -37,32 +34,3 @@ def test_cors_acao_header(
         assert "access-control-allow-origin" not in resp.headers, (
             f"Unexpected ACAO header present for request from '{origin}' to '{path}'"
         )
-
-
-@pytest.mark.parametrize(
-    "is_staff,in_group,expected",
-    (
-        (True, True, True),
-        (True, False, False),
-        (False, True, False),
-        (False, False, False),
-    ),
-)
-@pytest.mark.django_db
-def test_user_is_conduit_admin(is_staff: bool, in_group: bool, expected: bool):
-    user = User.objects.create_user("testuser", is_staff=is_staff)
-    if in_group:
-        group, _ = Group.objects.get_or_create(name=CONDUIT_ADMIN_GROUP_NAME)
-        group.user_set.add(user)
-
-    assert user_is_conduit_admin(user) is expected, (
-        f"A staff={is_staff}, in_group={in_group} user should "
-        f"{'' if expected else 'not '}be a Conduit admin."
-    )
-
-
-@pytest.mark.django_db
-def test_user_is_conduit_admin_anonymous():
-    assert user_is_conduit_admin(AnonymousUser()) is False, (
-        "An unauthenticated user should not be a Conduit admin."
-    )

--- a/src/lando/tests/test_middlewares.py
+++ b/src/lando/tests/test_middlewares.py
@@ -1,5 +1,8 @@
 import pytest
+from django.contrib.auth.models import AnonymousUser, Group, User
 from django.test.client import Client
+
+from lando.middleware import CONDUIT_ADMIN_GROUP_NAME, user_is_conduit_admin
 
 
 @pytest.mark.parametrize(
@@ -34,3 +37,32 @@ def test_cors_acao_header(
         assert "access-control-allow-origin" not in resp.headers, (
             f"Unexpected ACAO header present for request from '{origin}' to '{path}'"
         )
+
+
+@pytest.mark.parametrize(
+    "is_staff,in_group,expected",
+    (
+        (True, True, True),
+        (True, False, False),
+        (False, True, False),
+        (False, False, False),
+    ),
+)
+@pytest.mark.django_db
+def test_user_is_conduit_admin(is_staff: bool, in_group: bool, expected: bool):
+    user = User.objects.create_user("testuser", is_staff=is_staff)
+    if in_group:
+        group, _ = Group.objects.get_or_create(name=CONDUIT_ADMIN_GROUP_NAME)
+        group.user_set.add(user)
+
+    assert user_is_conduit_admin(user) is expected, (
+        f"A staff={is_staff}, in_group={in_group} user should "
+        f"{'' if expected else 'not '}be a Conduit admin."
+    )
+
+
+@pytest.mark.django_db
+def test_user_is_conduit_admin_anonymous():
+    assert user_is_conduit_admin(AnonymousUser()) is False, (
+        "An unauthenticated user should not be a Conduit admin."
+    )

--- a/src/lando/ui/jinja2/partials/navbar.html
+++ b/src/lando/ui/jinja2/partials/navbar.html
@@ -44,7 +44,7 @@
                                 </a>
                             </p>
                         {% endif %}
-                        {% if user_is_authenticated and request.user.is_superuser %}
+                        {% if user_is_authenticated and user_is_conduit_admin(request.user) %}
                             <p class="control">
                                 <a class="button" href="{{ url('admin:index') }}">
                                     <span class="icon">

--- a/src/lando/ui/jinja2/partials/navbar.html
+++ b/src/lando/ui/jinja2/partials/navbar.html
@@ -44,7 +44,7 @@
                                 </a>
                             </p>
                         {% endif %}
-                        {% if user_is_authenticated and user_is_conduit_admin(request.user) %}
+                        {% if user_is_conduit_admin(request.user) %}
                             <p class="control">
                                 <a class="button" href="{{ url('admin:index') }}">
                                     <span class="icon">

--- a/src/lando/utils/management/commands/setup_dev.py
+++ b/src/lando/utils/management/commands/setup_dev.py
@@ -5,10 +5,10 @@ from django.core.management.base import BaseCommand, CommandError
 
 from lando.environments import Environment
 from lando.headless_api.models.tokens import ApiToken
+from lando.main.auth import CONDUIT_ADMIN_GROUP_NAME
 from lando.main.models import Repo, Worker
 from lando.main.models.worker import WorkerType
 from lando.main.scm import SCMType
-from lando.middleware import CONDUIT_ADMIN_GROUP_NAME
 
 
 class Command(BaseCommand):


### PR DESCRIPTION
Extract a `user_is_conduit_admin` helper from the
`MaintenanceModeMiddleware` and switch the navbar
template to use it as a conditional check when
rendering the Admin button. Add a test for the extracted
helper while we're here.
