### PR TITLE
celery: pin worker concurrency to 2 (bug 2047652)

### DIFF
--- a/src/lando/settings.py
+++ b/src/lando/settings.py
@@ -274,6 +274,9 @@ CELERY_BROKER_URL = os.getenv("CELERY_BROKER_URL", "redis://lando.redis:6379")
 CELERY_RESULT_BACKEND = CELERY_BROKER_URL
 CELERY_ACCEPT_CONTENT = ["json"]
 CELERY_TASK_SERIALIZER = "json"
+# Pin the worker pool size; otherwise Celery sizes it to the node's CPU count,
+# inflating baseline CPU and tripping autoscaling (bug 2047652).
+CELERY_WORKER_CONCURRENCY = int(os.getenv("CELERY_WORKER_CONCURRENCY", "2"))
 
 
 PULSE_USERID = os.getenv("PULSE_USERID", "")


### PR DESCRIPTION
Celery defaulted its pool size to the node's CPU count, inflating baseline CPU
and tripping the celeryworker HPA. Pin it to 2 (env-overridable).
