### PR TITLE
admin: add `landing_strategy` and remove handover fields from admin (Bug 2048687)

### DIFF
--- a/src/lando/main/admin.py
+++ b/src/lando/main/admin.py
@@ -170,15 +170,12 @@ class LandingJobAdmin(JobAdmin):
         "landing_strategy",
         "is_pull_request_job",
         "target_repo",
-        "handover_repo",
-        "is_handed_over",
         "created_at",
         "updated_at",
     )
     readonly_fields = JobAdmin.readonly_fields + (
         "formatted_replacements",
         "is_pull_request_job",
-        "is_handed_over",
         "landing_strategy",
     )
     search_fields = JobAdmin.search_fields + (

--- a/src/lando/main/admin.py
+++ b/src/lando/main/admin.py
@@ -151,8 +151,7 @@ class LandingJobAdmin(JobAdmin):
         "status",
         "is_pull_request_job",
         "target_repo__name",
-        "handover_repo__name",
-        "is_handed_over",
+        "landing_strategy",
         "created_at",
         "requester_email",
         "duration_seconds",
@@ -168,6 +167,7 @@ class LandingJobAdmin(JobAdmin):
         "priority",
         "requester_email",
         "target_commit_hash",
+        "landing_strategy",
         "is_pull_request_job",
         "target_repo",
         "handover_repo",
@@ -179,12 +179,13 @@ class LandingJobAdmin(JobAdmin):
         "formatted_replacements",
         "is_pull_request_job",
         "is_handed_over",
+        "landing_strategy",
     )
     search_fields = JobAdmin.search_fields + (
         "unsorted_revisions__revision_id",
         "requester_email",
     )
-    list_filter = JobAdmin.list_filter + ("is_pull_request_job",)
+    list_filter = JobAdmin.list_filter + ("is_pull_request_job", "landing_strategy")
 
     def revisions(self, instance: LandingJob) -> str:
         """Return a summary of revisions present in a LandingJob


### PR DESCRIPTION
Add the `landing_strategy` field to the `LandingJobAdmin`. While we're
here, remove the handover repo fields from the admin UI to clear up some
space.
