### PR TITLE
ruff: annotate return types of protected and nested functions (bug 2048990)

### DIFF
--- a/src/lando/api/legacy/transplants.py
+++ b/src/lando/api/legacy/transplants.py
@@ -319,7 +319,9 @@ class RevisionWarningCheck:
 
     def __call__(self, f: Callable) -> Callable:
         @functools.wraps(f)
-        def wrapped(revision: dict, diff: dict, stack_state: StackAssessmentState):
+        def wrapped(
+            revision: dict, diff: dict, stack_state: StackAssessmentState
+        ) -> RevisionWarning | None:
             result = f(revision, diff, stack_state)
             return (
                 None

--- a/src/lando/main/auth.py
+++ b/src/lando/main/auth.py
@@ -226,7 +226,7 @@ def force_auth_refresh(f: Callable) -> Callable:
     Decorator which forces authenticated session to be refreshed.
     """
 
-    def wrapper(*args, **kwargs):
+    def wrapper(*args, **kwargs) -> HttpResponse:
         """Set oidc_id_token_expiration to 0, forcing session refresh."""
         # First check that SessionRefresh is indeed enabled.
         if "mozilla_django_oidc.middleware.SessionRefresh" not in settings.MIDDLEWARE:

--- a/src/lando/main/models/repo.py
+++ b/src/lando/main/models/repo.py
@@ -489,7 +489,7 @@ class Repo(BaseModel):
             user, str(self.required_automation_permission)
         )
 
-    def _user_has_direct_permission(self, user: User, permission: str):
+    def _user_has_direct_permission(self, user: User, permission: str) -> bool:
         """
         Test that the user has a specific permission directly rather than via a role.
 

--- a/src/lando/main/scm/git.py
+++ b/src/lando/main/scm/git.py
@@ -680,7 +680,7 @@ class GitSCM(AbstractSCM):
         self._git_run("clean", "-fdx", cwd=self.path)
 
     @property
-    def _git_dir(self):
+    def _git_dir(self) -> str:
         return self._git_run("rev-parse", "--absolute-git-dir", cwd=self.path)
 
     @override

--- a/src/lando/main/scm/hg.py
+++ b/src/lando/main/scm/hg.py
@@ -741,7 +741,7 @@ class HgSCM(AbstractSCM):
             self.path, encoding=self.ENCODING, configs=self._config_to_list()
         )
 
-    def _config_to_list(self):
+    def _config_to_list(self) -> list[str]:
         """Reformat the object's config, to a list of strings suitable for hglib"""
         return ["{}={}".format(k, v) for k, v in self.config.items() if v is not None]
 

--- a/src/lando/ui/legacy/stacks.py
+++ b/src/lando/ui/legacy/stacks.py
@@ -110,7 +110,7 @@ def draw_stack_graph(
     next_node = []
     drawing = SimpleNamespace(rows=[], width=0)
 
-    def empty_column_or_new():
+    def empty_column_or_new() -> int:
         """Return the index of an empty column or create a new one."""
         if not next_node.count(None):
             next_node.append(None)

--- a/src/lando/utils/github.py
+++ b/src/lando/utils/github.py
@@ -237,7 +237,7 @@ class GitHubAPIClient:
         elif content_type == "application/vnd.github.diff; charset=utf-8":
             return result.text
 
-    def _post(self, path: str, *args, **kwargs):
+    def _post(self, path: str, *args, **kwargs) -> dict:
         result = self._api.post(path, *args, **kwargs)
         return result.json()
 


### PR DESCRIPTION
Adds the return type annotations that `ANN202` requires, ahead of
removing the rule's exception from `ruff.toml`.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>