### PR TITLE
ruff: remove `ANN201` noqas from notification helpers (bug 2048990)

### DIFF
--- a/src/lando/api/legacy/notifications.py
+++ b/src/lando/api/legacy/notifications.py
@@ -1,6 +1,7 @@
 import logging
 
 import kombu
+from celery.result import AsyncResult
 
 from lando.utils.tasks import (
     send_bug_update_failure_email,
@@ -10,9 +11,9 @@ from lando.utils.tasks import (
 logger = logging.getLogger(__name__)
 
 
-def notify_user_of_landing_failure(  # noqa: ANN201
+def notify_user_of_landing_failure(
     email: str, landing_job_identifier: str, error: str, request_id: int
-):
+) -> AsyncResult:
     """Send out user notifications that a Landing failed.
 
     Args:
@@ -52,9 +53,9 @@ def notify_user_of_landing_failure(  # noqa: ANN201
         raise
 
 
-def notify_user_of_bug_update_failure(  # noqa: ANN201
+def notify_user_of_bug_update_failure(
     email: str, revision: str, error: str, request_id: int
-):
+) -> AsyncResult:
     """Send out user notifications that a bug update failed.
 
     Args:


### PR DESCRIPTION
Annotates the return types of the public `notify_user_of_*` functions.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>