### PR TITLE
ruff: remove `ANN001` noqas and annotate function arguments (bug 2048990)

### DIFF
--- a/src/lando/dockerflow/decorators.py
+++ b/src/lando/dockerflow/decorators.py
@@ -1,13 +1,19 @@
 import logging
 import time
+from collections.abc import Callable
 from functools import wraps
+
+from django.http import HttpRequest, HttpResponse
+from django.views import View
 
 request_logger = logging.getLogger("__name__")
 
 
-def log_request(view):  # noqa: ANN001, ANN201
+def log_request(view: Callable) -> Callable:
     @wraps(view)
-    def _wrapped_view(self, request, *args, **kwargs):  # noqa: ANN001
+    def _wrapped_view(
+        self: View, request: HttpRequest, *args, **kwargs
+    ) -> HttpResponse:
         start_time = time.time()
         response = view(self, request, *args, **kwargs)
         end_time = time.time()
@@ -29,9 +35,11 @@ def log_request(view):  # noqa: ANN001, ANN201
     return _wrapped_view
 
 
-def disable_caching(view):  # noqa: ANN001, ANN201
+def disable_caching(view: Callable) -> Callable:
     @wraps(view)
-    def _wrapped_view(self, request, *args, **kwargs):  # noqa: ANN001
+    def _wrapped_view(
+        self: View, request: HttpRequest, *args, **kwargs
+    ) -> HttpResponse:
         response = view(self, request, *args, **kwargs)
 
         response["Cache-Control"] = "no-cache, no-store, must-revalidate"

--- a/src/lando/dockerflow/views.py
+++ b/src/lando/dockerflow/views.py
@@ -1,6 +1,6 @@
 from django.db import connection
 from django.db.utils import OperationalError
-from django.http import JsonResponse
+from django.http import HttpRequest, HttpResponse, JsonResponse
 from django.views import View
 
 from lando.dockerflow.decorators import disable_caching, log_request
@@ -15,11 +15,11 @@ class DockerflowView(View):
 
     @disable_caching
     @log_request
-    def dispatch(self, request, *args, **kwargs):  # noqa: ANN001, ANN201
+    def dispatch(self, request: HttpRequest, *args, **kwargs) -> HttpResponse:
         return super().dispatch(request, *args, **kwargs)
 
     @staticmethod
-    def _json_response(data, status):  # noqa: ANN001, ANN205
+    def _json_response(data: dict, status: int) -> JsonResponse:
         return JsonResponse(data, status=status, json_dumps_params={"indent": 2})
 
 
@@ -30,7 +30,7 @@ class VersionView(DockerflowView):
     It returns a JSON response containing the version information.
     """
 
-    def get(self, request):  # noqa: ANN001, ANN201
+    def get(self, request: HttpRequest) -> JsonResponse:
         try:
             from lando.version import version
         except ImportError:
@@ -53,7 +53,7 @@ class HeartbeatView(DockerflowView):
     It returns a JSON response containing the heartbeat information.
     """
 
-    def get(self, request):  # noqa: ANN001, ANN201
+    def get(self, request: HttpRequest) -> JsonResponse:
         try:
             connection.ensure_connection()
         except OperationalError:
@@ -81,5 +81,5 @@ class LoadBalancerHeartbeatView(DockerflowView):
     It simply returns a JSON response with status 200.
     """
 
-    def get(self, request):  # noqa: ANN001, ANN201
+    def get(self, request: HttpRequest) -> JsonResponse:
         return self._json_response(data={}, status=200)

--- a/src/lando/main/admin.py
+++ b/src/lando/main/admin.py
@@ -3,6 +3,7 @@ from typing import Callable, Self
 
 from django.contrib import admin
 from django.db.models import Field as DbField
+from django.db.models import Model
 from django.forms import CheckboxSelectMultiple, MultipleChoiceField
 from django.forms import Field as FormField
 from django.http import HttpRequest
@@ -63,7 +64,7 @@ class ReadOnlyInline(admin.TabularInline):
         [0] https://forum.djangoproject.com/t/show-all-the-fields-in-inline-of-the-many-to-many-model-instead-of-a-simple-dropdown/28062/7
         """
 
-        def getter(self: Self):
+        def getter(self: Self) -> object:
             return getattr(getattr(self, cls._target_object), f)
 
         getter.__name__ = f
@@ -76,15 +77,21 @@ class ReadOnlyInline(admin.TabularInline):
                 setattr(self, f, self._field_getter_factory(f))
         super().__init__(*args, **kwargs)
 
-    def has_add_permission(self, request, obj=None) -> bool:  # noqa: ANN001
+    def has_add_permission(
+        self, request: HttpRequest, obj: Model | None = None
+    ) -> bool:
         """Forbid addition of any pushlog object from the admin interface."""
         return self.can_add
 
-    def has_change_permission(self, request, obj=None) -> bool:  # noqa: ANN001
+    def has_change_permission(
+        self, request: HttpRequest, obj: Model | None = None
+    ) -> bool:
         """Forbid change of any pushlog object from the admin interface."""
         return self.can_change
 
-    def has_delete_permission(self, request, obj=None) -> bool:  # noqa: ANN001
+    def has_delete_permission(
+        self, request: HttpRequest, obj: Model | None = None
+    ) -> bool:
         """Forbid deletion of any pushlog object from the admin interface."""
         return self.can_delete
 

--- a/src/lando/main/support.py
+++ b/src/lando/main/support.py
@@ -1,3 +1,4 @@
+from django.core.files.base import File
 from django.core.files.storage import storages
 from storages.backends.gcloud import GoogleCloudStorage
 
@@ -15,14 +16,14 @@ class CachedGoogleCloudStorage(GoogleCloudStorage):
             {"BACKEND": "compressor.storage.CompressorFileStorage"}
         )
 
-    def save(self, name, content):  # noqa: ANN001, ANN201
+    def save(self, name: str, content: File) -> str:
         self.local_storage.save(name, content)
         super().save(name, self.local_storage._open(name))
         return name
 
 
 class LegacyAPIException(Exception):
-    def __init__(self, status, detail, extra=None):  # noqa: ANN001
+    def __init__(self, status: int, detail: str, extra: dict | None = None):
         self.status = status
         self.detail = detail
         self.extra = extra

--- a/src/lando/pushlog/admin.py
+++ b/src/lando/pushlog/admin.py
@@ -1,4 +1,6 @@
 from django.contrib import admin
+from django.db.models import Model
+from django.http import HttpRequest
 
 from lando.main.admin import ReadOnlyInline
 from lando.pushlog.models import (
@@ -12,15 +14,21 @@ from lando.pushlog.models import (
 class PushLogAdmin(admin.ModelAdmin):
     """A base ModelAdmin class for PushLog-related admin parameters."""
 
-    def has_add_permission(self, request, obj=None) -> bool:  # noqa: ANN001
+    def has_add_permission(
+        self, request: HttpRequest, obj: Model | None = None
+    ) -> bool:
         """Forbid addition of any pushlog object from the admin interface."""
         return False
 
-    def has_change_permission(self, request, obj=None) -> bool:  # noqa: ANN001
+    def has_change_permission(
+        self, request: HttpRequest, obj: Model | None = None
+    ) -> bool:
         """Forbid change of any pushlog object from the admin interface."""
         return False
 
-    def has_delete_permission(self, request, obj=None) -> bool:  # noqa: ANN001
+    def has_delete_permission(
+        self, request: HttpRequest, obj: Model | None = None
+    ) -> bool:
         """Forbid deletion of any pushlog object from the admin interface."""
         return False
 


### PR DESCRIPTION
Annotates arguments (and the return types on the same signatures) for
the dockerflow views/decorators, admin permission methods and support
helpers.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>