### PR TITLE
ruff: remove the `ANN202` exception (bug 2048990)

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -8,8 +8,6 @@ lint.ignore = [
     "E501",
     "ANN002",  # Missing type annotation for *args
     "ANN003",  # Missing type annotation for **kwargs
-    "ANN202",  # Missing return type annotation for protected function
-
 ]
 exclude = [
     ".cache",


### PR DESCRIPTION
All protected and nested functions are now annotated, so the rule can
be enforced.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>