### PR TITLE
Update Thunderbird staging repo to infra-testing

### DIFF
--- a/src/lando/utils/management/commands/create_environment_repos.py
+++ b/src/lando/utils/management/commands/create_environment_repos.py
@@ -223,10 +223,10 @@ for branch in ["main", "autoland", "beta", "release", "esr115", "esr128", "esr14
 for branch in ["main", "beta", "release", "esr140"]:
     REPOS[Environment.staging].append(
         {
-            "name": f"staging-thunderbird-desktop-{branch}",
+            "name": f"thunderbird-infra-testing-{branch}",
             "default_branch": branch,
-            "url": "https://github.com/thunderbird/thunderbird-desktop-staging.git",
-            "short_name": f"staging-thunderbird-desktop-{branch}",
+            "url": "https://github.com/thunderbird/infra-testing.git",
+            "short_name": f"thunderbird-infra-testing-{branch}",
             "required_permission": SCM_LEVEL_3,
             "automation_enabled": True,
         }


### PR DESCRIPTION
We've renamed our staging repo for Thunderbird to infra-testing. The current URL, although it redirects to infra-testing, does not work (Lando returns HTTP 422).