### PR TITLE
treestatus: invalidate and share the tree-status cache across processes (bug 2050889)

### DIFF
--- a/src/lando/settings.py
+++ b/src/lando/settings.py
@@ -22,13 +22,24 @@ ENVIRONMENT = Environment(os.getenv("ENVIRONMENT", "test"))
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent
 
+# The `db` cache is a shared cache used by Treestatus so that invalidation from
+# one process is visible to the others; remote environments back it with the
+# database (see `remote_settings`), while locally it is per-process.
+CACHES = {
+    "default": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+    },
+    "db": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+    },
+}
+
+# Use a shared Redis cache for the default cache when configured.
 # Syntax: redis://[username:password@]127.0.0.1:6379
 if lando_cache_redis := os.getenv("LANDO_CACHE_REDIS"):
-    CACHES = {
-        "default": {
-            "BACKEND": "django.core.cache.backends.redis.RedisCache",
-            "LOCATION": lando_cache_redis,
-        }
+    CACHES["default"] = {
+        "BACKEND": "django.core.cache.backends.redis.RedisCache",
+        "LOCATION": lando_cache_redis,
     }
 
 SECRET_KEY = os.getenv(

--- a/src/lando/test_settings.py
+++ b/src/lando/test_settings.py
@@ -19,7 +19,10 @@ ENVIRONMENT = Environment.test
 CACHES = {
     "default": {
         "BACKEND": "django.core.cache.backends.dummy.DummyCache",
-    }
+    },
+    "db": {
+        "BACKEND": "django.core.cache.backends.dummy.DummyCache",
+    },
 }
 
 DEFAULT_FROM_EMAIL = "Lando <lando@lando.test>"

--- a/src/lando/treestatus/views/api.py
+++ b/src/lando/treestatus/views/api.py
@@ -9,7 +9,7 @@ from typing import (
     TypeVar,
 )
 
-from django.core.cache import cache
+from django.core.cache import caches
 from django.core.handlers.wsgi import WSGIRequest
 from django.db.models import OuterRef, Subquery
 from django.db.utils import IntegrityError
@@ -42,6 +42,11 @@ treestatus_api = NinjaAPI(auth=None, urls_namespace="treestatus-api")
 treestatus_api.exception_handler(ProblemException)(problem_exception_handler)
 
 TREE_SUMMARY_LOG_LIMIT = 5
+
+# Treestatus caches tree lookups in the shared database cache so that an
+# invalidation from one process (e.g. a tree update on one web head) is visible
+# to every other web head and the worker, unlike the per-process default cache.
+TREESTATUS_CACHE = "db"
 
 
 # Generic type variable for the data contained in a result field.
@@ -196,7 +201,7 @@ def tree_cache_key(tree_name: str) -> str:
     return f"tree-cache-{tree_name}"
 
 
-@cache_method(tree_cache_key)
+@cache_method(tree_cache_key, cache_alias=TREESTATUS_CACHE)
 def get_tree_by_name(tree_name: str) -> Optional[CombinedTree]:
     """Retrieve a `CombinedTree` representation of a tree by name.
 
@@ -247,7 +252,7 @@ def remove_tree_by_name(tree_name: str):
 
     StatusChangeTree.objects.filter(tree=tree_name).delete()
 
-    cache.delete(tree_cache_key(tree_name))
+    caches[TREESTATUS_CACHE].delete(tree_cache_key(tree_name))
 
 
 def update_tree_log(
@@ -271,7 +276,7 @@ def update_tree_log(
         log.reason = reason
 
     log.save()
-    cache.delete(tree_cache_key(log.tree.tree))
+    caches[TREESTATUS_CACHE].delete(tree_cache_key(log.tree.tree))
 
 
 def get_combined_trees(trees: Optional[list[str]] = None) -> list[CombinedTree]:
@@ -331,7 +336,7 @@ def apply_tree_update_to_model(
             tags=tags,
         )
 
-    cache.delete(tree_cache_key(tree.tree))
+    caches[TREESTATUS_CACHE].delete(tree_cache_key(tree.tree))
 
 
 @treestatus_api.get(

--- a/src/lando/utils/cache.py
+++ b/src/lando/utils/cache.py
@@ -4,7 +4,7 @@ from typing import (
     TypeVar,
 )
 
-from django.core.cache import cache
+from django.core.cache import caches
 
 # Generic type representing the content being cached.
 T = TypeVar("T")
@@ -12,17 +12,24 @@ T = TypeVar("T")
 
 def cache_method(
     key_fn: Callable[..., str],
+    cache_alias: str = "default",
 ) -> Callable[[Callable[..., T]], Callable[..., T]]:
     """Cache the method result using the key function.
 
-    Decorator factory that caches the result of a method using
-    the provided key function.
+    Decorator factory that caches the result of a method using the provided key
+    function, in the cache named by `cache_alias`. Callers that invalidate an
+    entry must delete it from the same cache.
     """
 
     def decorator(func: Callable[..., T]) -> Callable[..., T]:
         @functools.wraps(func)
         def wrapper(*args, **kwargs) -> T:
-            key = f"cache_method_{func.__qualname__}_" + key_fn(*args, **kwargs)
+            cache = caches[cache_alias]
+
+            # The key function fully determines the cache key, so callers can
+            # build the same key to invalidate an entry. Key functions must
+            # therefore return a value unique to each cached function.
+            key = key_fn(*args, **kwargs)
 
             if cache.has_key(key):
                 return cache.get(key)

--- a/src/lando/utils/github.py
+++ b/src/lando/utils/github.py
@@ -4,7 +4,7 @@ import logging
 import math
 import re
 from collections import Counter
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from datetime import datetime
 from enum import Enum
 from itertools import count
@@ -405,17 +405,21 @@ class GitHubAPIClient:
         return str(math.floor(timestamp_datetime.timestamp()))
 
 
-def pr_cache_key(self: "PullRequest", *args, **kwargs) -> str:
-    """Provide a cache key for PR methods that fetch data from GitHub.
+def pr_cache_method(func: Callable) -> Callable:
+    """Cache a `PullRequest` method, keyed by the method and the PR's version.
 
-    This method-like function cannot be part of the PullRequest, as it is used by method
-    decorators when declaring the class.
+    The wrapped function's name namespaces the key so the several PR methods
+    sharing this decorator do not collide on a single key, and changes to
+    `updated_at` naturally invalidate the entry.
+
+    This decorator cannot be part of `PullRequest`, as it is used when declaring
+    the class.
     """
-    return f"{self.id}{self.updated_at}"
 
+    def pr_cache_key(self: "PullRequest", *args, **kwargs) -> str:
+        return f"pr-{func.__name__}-{self.id}{self.updated_at}"
 
-# Specialised decorator which embeds the PR-specific cache-key builder.
-pr_cache_method = cache_method(pr_cache_key)
+    return cache_method(pr_cache_key)(func)
 
 
 class PullRequest:

--- a/src/lando/utils/tests/test_cache.py
+++ b/src/lando/utils/tests/test_cache.py
@@ -44,16 +44,10 @@ def test_cache_method():
     assert result3 == "Hello, Bob!"
     assert call_counter["count"] == 2
 
-    # Confirm cache has both keys stored
-    assert (
-        cache.get(
-            "cache_method_test_cache_method.<locals>.expensive_function_test-cache-Alice"
-        )
-        == "Hello, Alice!"
+    # Confirm the cache is keyed purely on the key function's output.
+    assert cache.get("test-cache-Alice") == "Hello, Alice!", (
+        "The cached value should be stored under the key function's output."
     )
-    assert (
-        cache.get(
-            "cache_method_test_cache_method.<locals>.expensive_function_test-cache-Bob"
-        )
-        == "Hello, Bob!"
+    assert cache.get("test-cache-Bob") == "Hello, Bob!", (
+        "The cached value should be stored under the key function's output."
     )


### PR DESCRIPTION
Key `cache_method` entries solely on the key function's output so the Treestatus
write paths actually invalidate `get_tree_by_name`, and derive the GitHub PR cache
key from the wrapped function so its methods stay distinct without the prefix.
Route the tree-lookup cache through the shared database-backed `db` cache so an
invalidation on one process is seen by every web head and the worker.
