### PR TITLE
landing_checks: add backend validation to warning acknowledgements for pull requests (bug 2000955)

### DIFF
--- a/src/lando/api/tests/test_views.py
+++ b/src/lando/api/tests/test_views.py
@@ -162,6 +162,7 @@ def test__views__phabricator_auth_backend_invalid_token(
 @mock.patch("lando.api.views.GitHubAPIClient")
 @pytest.mark.django_db(transaction=True)
 def test__views__pull_request_api_view__private_repo(github_api_client, client):
+
     mock_github_api_client = mock.MagicMock()
     mock_pr = mock.MagicMock()
 
@@ -561,3 +562,78 @@ class TestViewsPullRequestUpdateWebHook:
         )
         assert response.status_code == 202
         assert mock_github_api_client.update_pull_request_body.call_count == 0
+
+
+@mock.patch("lando.api.views.generate_warnings_and_blockers")
+@mock.patch("lando.api.views.GitHubAPIClient")
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.parametrize(
+    "warnings_1, warnings_2, expected_status, expected_response",
+    [
+        (["warning-1", "warning-2"], ["warning-1", "warning-2"], 201, b""),
+        (
+            ["warning-1", "warning-2"],
+            ["warning-3", "warning-4"],
+            400,
+            [
+                "The warnings present when the request was constructed have changed. Please acknowledge the new warnings and try again."
+            ],
+        ),
+    ],
+)
+def test__views_landing_job_pull_request_view__warnings(
+    github_api_client,
+    mock_warnings_and_blockers,
+    authenticated_client,
+    repo_mc_github_api_client,
+    repo_mc,
+    warnings_1,
+    warnings_2,
+    expected_status,
+    expected_response,
+):
+    repo = repo_mc(SCMType.GIT)
+    github_api_client.return_value = repo_mc_github_api_client
+
+    mock_pr = mock.MagicMock()
+    repo_mc_github_api_client.build_pull_request.return_value = mock_pr
+    mock_pr.author = ("Test Author", "test@email.com")
+    mock_pr.commit_message = "Test Commit Message"
+    mock_pr.number = 1
+    mock_pr.head_sha = "aaa123"
+    mock_pr.base_sha = "bbb123"
+    mock_pr.patch = "diff --git a/abc b/def\n"
+    mock_pr.reviews_summary = {}
+
+    mock_warnings_and_blockers.return_value = {
+        "warnings": warnings_1,
+        "blockers": [],
+    }
+
+    old_warnings = authenticated_client.get(
+        f"/api/pulls/{repo.name}/1/checks",
+        content_type="application/json",
+    ).json()["warnings"]
+
+    mock_warnings_and_blockers.return_value = {
+        "warnings": warnings_2,
+        "blockers": [],
+    }
+
+    response = authenticated_client.post(
+        f"/api/pulls/{repo.name}/1/landing_jobs",
+        data={
+            "head_sha": "aaa123",
+            "base_sha": "bbb123",
+            "pull_number": 1,
+            "old_warnings": old_warnings,
+        },
+        content_type="application/json",
+    )
+
+    assert response.status_code == expected_status
+    if expected_status == 400:
+        new_warnings = response.json()["new_warnings"]
+
+        assert new_warnings == mock_warnings_and_blockers.return_value["warnings"]
+        assert response.json()["errors"] == {"warnings": expected_response}

--- a/src/lando/api/views.py
+++ b/src/lando/api/views.py
@@ -285,24 +285,44 @@ class LandingJobPullRequestAPIView(PullRequestAPIView):
         class Form(forms.Form):
             """Simple form to get clean some fields."""
 
+            def clean(self):
+
+                cleaned_data = self.cleaned_data
+                new_warnings = cleaned_data["new_warnings"]
+                old_warnings = cleaned_data["old_warnings"]
+                if sorted(new_warnings) != sorted(old_warnings):
+                    self.errors["warnings"] = [
+                        "The warnings present when the request was constructed have changed. "
+                        "Please acknowledge the new warnings and try again."
+                    ]
+
+                return cleaned_data
+
             head_sha = forms.CharField()
+            new_warnings = forms.JSONField()
+            old_warnings = forms.JSONField()
             # TODO: use this for verification later, see bug 1996571.
             # base_ref = forms.CharField()
 
         ldap_username = request.user.email
 
-        blockers = generate_warnings_and_blockers(
+        warnings_and_blockers = generate_warnings_and_blockers(
             self.target_repo, self.pull_request, request
-        )["blockers"]
+        )
+        new_warnings = warnings_and_blockers["warnings"]
 
-        if blockers:
-            # Pull request has blockers that prevent it from landing.
+        if blockers := warnings_and_blockers["blockers"]:
             return JsonResponse({"errors": blockers}, status=400)
 
-        form = Form(json.loads(request.body))
+        data = json.loads(request.body)
+        # add new warnings to the data so that the form can validate that they match the old warnings
+        data["new_warnings"] = new_warnings
+        form = Form(data)
 
         if not form.is_valid():
-            return JsonResponse(form.errors, 400)
+            return JsonResponse(
+                {"errors": form.errors, "new_warnings": new_warnings}, status=400
+            )
 
         job = LandingJob.objects.create(
             target_repo=self.target_repo,

--- a/src/lando/static_src/legacy/js/components/Stack.js
+++ b/src/lando/static_src/legacy/js/components/Stack.js
@@ -1,5 +1,16 @@
 "use strict";
 
+// Label shown on the landing button when unacknowledged warnings block landing.
+const ACKNOWLEDGE_WARNINGS_LABEL = "Acknowledge warnings to continue";
+
+// Put the landing button into the state that requires the user to acknowledge
+// warnings before landing can proceed.
+function need_warnings_acknowledgements(button) {
+    button.prop("disabled", true);
+    button.removeClass("is-loading is-danger").addClass("is-warning");
+    button.html(ACKNOWLEDGE_WARNINGS_LABEL);
+}
+
 $.fn.stack = function () {
     return this.each(function () {
         let $stack = $(this);
@@ -87,8 +98,7 @@ $.fn.stack = function () {
                     pull_request_button.prop("disabled", false);
                     pull_request_button.html("Request landing despite warnings");
                 } else {
-                    pull_request_button.prop("disabled", true);
-                    pull_request_button.html("Acknowledge warnings to continue");
+                    need_warnings_acknowledgements(pull_request_button);
                 }
             });
 
@@ -103,6 +113,7 @@ $.fn.stack = function () {
             var head_sha = pull_request_button.data("head-sha");
             var repo_name = pull_request_button.data("repo-name");
             var csrf_token = pull_request_button.data("csrf-token");
+            var old_warnings = [];
 
             fetch(`/api/pulls/${repo_name}/${pull_number}/landing_jobs`, {
                 method: "GET",
@@ -143,7 +154,7 @@ $.fn.stack = function () {
                                 var result = await response.json();
                                 var blockers = result.blockers;
                                 var warnings = result.warnings;
-
+                                old_warnings = warnings;
                                 var has_blockers = blockers.length !== 0;
                                 var has_warnings = warnings.length !== 0;
                                 var success_placeholder = `<li><span class="fa-li has-text-success"><i class="fa fa-check"></i></span>None found.</li>`;
@@ -184,13 +195,7 @@ $.fn.stack = function () {
                                     pull_request_button.html("Landing is blocked");
                                 } else if (has_warnings) {
                                     $(".acknowledge-warnings-section").show();
-                                    pull_request_button.prop("disabled", true);
-                                    pull_request_button
-                                        .removeClass("is-loading")
-                                        .addClass("is-warning");
-                                    pull_request_button.html(
-                                        "Acknowledge warnings to continue",
-                                    );
+                                    need_warnings_acknowledgements(pull_request_button);
                                 }
                                 saved_landing_state = {
                                     html: pull_request_button.html(),
@@ -217,22 +222,42 @@ $.fn.stack = function () {
                 pull_request_button.addClass("is-loading");
                 fetch(`/api/pulls/${repo_name}/${pull_number}/landing_jobs`, {
                     method: "POST",
-                    body: JSON.stringify({ head_sha: head_sha }),
+                    body: JSON.stringify({
+                        head_sha: head_sha,
+                        old_warnings: old_warnings,
+                    }),
                     headers: {
                         Accept: "application/json",
                         "Content-Type": "application/json",
                         "X-CSRFToken": csrf_token,
                     },
-                }).then((response) => {
+                }).then(async (response) => {
                     if (response.status == 201) {
                         window.location.reload();
                     } else if (response.status == 400) {
-                        pull_request_button.prop("disabled", true);
+                        var result = await response.json();
                         pull_request_button
                             .removeClass("is-danger")
                             .removeClass("is-loading")
                             .addClass("is-warning");
-                        pull_request_button.html("Could not create landing job");
+                        pull_request_button.prop("disabled", true);
+
+                        if ("new_warnings" in result) {
+                            $("#warnings-mismatch").append(
+                                `<li>${result["errors"]["warnings"]}</li>`,
+                            );
+                            $("#warnings").empty();
+                            $("#acknowledge-warnings").prop("checked", false);
+                            need_warnings_acknowledgements(pull_request_button);
+                            var new_warnings = result["new_warnings"];
+                            for (var warning of new_warnings) {
+                                $("#warnings").append(
+                                    `<li><span class="fa-li has-text-warning"><i class="fa fa-warning"></i></span>${warning}</li>`,
+                                );
+                            }
+                        } else {
+                            pull_request_button.html("Could not create landing job");
+                        }
                     } else {
                         pull_request_button.prop("disabled", true);
                         pull_request_button

--- a/src/lando/ui/jinja2/stack/pull_request.html
+++ b/src/lando/ui/jinja2/stack/pull_request.html
@@ -25,6 +25,13 @@
         </p>
         <table>
             <tr>
+                <th></th>
+                <td>
+                    <ul id="warnings-mismatch" class="has-text-warning">
+                    </ul>
+                </td>
+            </tr>
+            <tr>
                 <th>Warnings</th>
                 <td>
                     <ul id="warnings" class="fa-ul">


### PR DESCRIPTION
Currently, the Lando UI only enables/disables the post landing job button based on the checkbox, without validating if there are any additional checks that have been created since the page loaded.

Upon clicking the landing button, check if the warnings have changed since the page loaded. If so, alert user of the change, display new warnings, and prompt again for warning acknowledgement.

Video of UI:

https://github.com/user-attachments/assets/af8a7b1b-b290-4ad2-a013-7ab228a7cb0e
<!--/ -+-+- DO NOT MODIFY THIS LINE - ENTER COMMIT MESSAGE ABOVE -+-+- /-->
---
Lando: [link](https://lando.moz.tools/pulls/lando/1274/)
Bugzilla: [bug 2000955](https://bugzilla.mozilla.org/show_bug.cgi?id=2000955)

:warning: This pull request has 4 warnings.
:no_entry_sign: This pull request has 1 blocker.