### PR TITLE
uplift_worker: disable auto try push for secure uplifts (bug 2053811)

### DIFF
--- a/src/lando/api/legacy/workers/uplift_worker.py
+++ b/src/lando/api/legacy/workers/uplift_worker.py
@@ -27,6 +27,7 @@ from lando.main.scm import GitSCM
 from lando.main.scm.commit import CommitData
 from lando.main.scm.helpers import PatchHelper
 from lando.try_api.api import get_commit_hash, get_commit_map
+from lando.utils.landing_checks import BugReferencesCheck
 from lando.utils.tasks import (
     send_uplift_failure_email,
     send_uplift_success_email,
@@ -166,12 +167,12 @@ class UpliftWorker(Worker):
         # `LANDED` is the same as "success".
         job.status = JobStatus.LANDED
         job.save()
-
         if ConfigurationVariable.get(ConfigurationKey.UPLIFT_TRY_ENABLED, True):
             try:
                 try_job = self.create_uplift_try_push(
                     base_revision, repo.scm_type, job, scm, new_commits
                 )
+
             except Exception:
                 logger.exception(
                     "Failed to create try push for uplift job.",
@@ -317,6 +318,11 @@ class UpliftWorker(Worker):
         new_commits: Iterable[CommitData],
     ) -> LandingJob:
         """Create a Try `LandingJob` for the commits landed by an uplift job."""
+        patch_helpers = list(scm.get_patch_helpers_for_commits(new_commits))
+        result = self.check_uplift_bug_references(patch_helpers)
+        if result:
+            raise ValueError(result)
+
         try_repo = Repo.objects.get(name="try")
 
         if try_repo.scm_type != repo_scm_type:
@@ -342,13 +348,12 @@ class UpliftWorker(Worker):
                 raise
 
         with transaction.atomic():
-            revisions = []
-            patch_helpers = scm.get_patch_helpers_for_commits(new_commits)
-            for patch_helper in patch_helpers:
-                revisions.append(self.create_revisions_from_patch_helper(patch_helper))
+            revisions = [
+                self.create_revisions_from_patch_helper(patch_helper)
+                for patch_helper in patch_helpers
+            ]
             try_revision = self.create_try_revision(job.requester_email)
             revisions.append(try_revision)
-
             try_job = LandingJob.objects.create(
                 target_repo=try_repo,
                 requester_email=job.requester_email,
@@ -358,6 +363,17 @@ class UpliftWorker(Worker):
             add_revisions_to_job(revisions, try_job)
             try_job.save()
         return try_job
+
+    def check_uplift_bug_references(
+        self, patch_helpers: list[PatchHelper]
+    ) -> str | None:
+        """Check if uplift job contains references to non-public bugs.
+
+        Return the error message when a referenced bug is not public, and `None` otherwise."""
+        secure_check = BugReferencesCheck()
+        for patch_helper in patch_helpers:
+            secure_check.next_diff(patch_helper)
+        return secure_check.result()
 
     def create_try_diff_from_json(self) -> str:
         try_config_path = (

--- a/src/lando/api/tests/test_uplift.py
+++ b/src/lando/api/tests/test_uplift.py
@@ -10,6 +10,7 @@ from packaging.version import (
     Version,
 )
 
+from lando.api.legacy.commit_message import parse_bugs
 from lando.api.legacy.uplift import (
     create_uplift_bug_update_payload,
     parse_milestone_version,
@@ -105,7 +106,6 @@ def test_uplift_creation_uses_existing_revisions_and_links_jobs(
         create_patch_revision(123, patch=normal_patch(0)),
     ]
     revisions_ordered = reversed(revisions_created)
-
     url = reverse("uplift-page")
     form_data = {
         "source_revisions": [revision.revision_id for revision in revisions_ordered],
@@ -723,10 +723,12 @@ def test_link_assessment_replaces_existing_form(
 
 
 @pytest.mark.django_db
+@pytest.mark.parametrize("secure", [True, False])
 def test_uplift_worker_applies_patches_and_creates_uplift_revision_success_git(
     repo_mc,
     user,
     uplift_worker,
+    secure,
     create_patch_revision,
     normal_patch,
     monkeypatch,
@@ -775,6 +777,22 @@ def test_uplift_worker_applies_patches_and_creates_uplift_revision_success_git(
         mock_task,
     )
 
+    mock_bug_search = mock.MagicMock()
+    mock_status_code = mock.MagicMock()
+    if secure:
+        mock_bug_search.return_value = set()
+        mock_status_code.return_value = 401
+
+    else:
+        bug_ids = parse_bugs(revisions[0].commit_message)
+        mock_bug_search.return_value = set(bug_ids)
+        mock_status_code.return_value = 200
+
+    monkeypatch.setattr(
+        "lando.utils.landing_checks.get_status_code_for_bug",
+        mock_status_code,
+    )
+    monkeypatch.setattr("lando.utils.landing_checks.search_bugs", mock_bug_search)
     # Let update_repo/apply_patch run for real and only mock moz-phab uplift to return new tip D-IDs.
     monkeypatch.setattr(
         uplift_worker,
@@ -865,25 +883,32 @@ def test_uplift_worker_applies_patches_and_creates_uplift_revision_success_git(
         "Created UpliftRevision should link back to the original assessment."
     )
 
-    try_jobs = LandingJob.objects.filter(target_repo=try_repo)
-    assert try_jobs.count() == 1, "A single try-push `LandingJob` should be created."
-
-    try_job = try_jobs.get()
-    assert try_job.target_commit_hash == mapped_hg_hash, (
-        "Try-push base should be converted to the try repo's SCM via CommitMap."
-    )
-    assert try_job.status == JobStatus.SUBMITTED, (
-        "Try-push job should be submitted for processing."
-    )
-    assert try_job.requester_email == user.email, (
-        "Try-push job should record the original requester."
-    )
-    assert try_job.target_commit_hash, "Try-push job should have a base commit hash."
-
-    # One revision per uplift revision, plus the try_task_config revision.
-    assert try_job.revisions.count() == len(revisions) + 1, (
-        "Try-push job should bundle the uplift revisions and the config revision."
-    )
+    if secure:
+        assert not LandingJob.objects.filter(target_repo__name="try").exists(), (
+            "Secure uplift should not create a public Try push."
+        )
+    else:
+        try_jobs = LandingJob.objects.filter(target_repo=try_repo)
+        assert try_jobs.count() == 1, (
+            "A single try-push `LandingJob` should be created."
+        )
+        try_job = try_jobs.get()
+        assert try_job.target_commit_hash == mapped_hg_hash, (
+            "Try-push base should be converted to the try repo's SCM via CommitMap."
+        )
+        assert try_job.status == JobStatus.SUBMITTED, (
+            "Try-push job should be submitted for processing."
+        )
+        assert try_job.requester_email == user.email, (
+            "Try-push job should record the original requester."
+        )
+        assert try_job.target_commit_hash, (
+            "Try-push job should have a base commit hash."
+        )
+        # One revision per uplift revision, plus the try_task_config revision.
+        assert try_job.revisions.count() == len(revisions) + 1, (
+            "Try-push job should bundle the uplift revisions and the config revision."
+        )
 
     # Mock `moz-phab uplift` again with new created commits.
     monkeypatch.setattr(


### PR DESCRIPTION
Automatic try-pushes for for security uplift requests currently give an error sent in a email notification. 

Avoid automatically pushing to try for security uplifts by adding a new is_secure boolean field in `UpliftSubmission` model, setting the status in the uplift post request, detecting this status in the uplift worker, and skipping the try push based on this detection.
<!--/ -+-+- DO NOT MODIFY THIS LINE - ENTER COMMIT MESSAGE ABOVE -+-+- /-->

---

Lando: [link](https://lando.moz.tools/pulls/lando/1329/)
Bugzilla: [bug 2053811](https://bugzilla.mozilla.org/show_bug.cgi?id=2053811)

:warning: This pull request has 7 warnings.
:no_entry_sign: This pull request has 1 blocker.