### PR TITLE
github: set PullRequestPatchHelper.metadata (bug 2054799)

### DIFF
--- a/src/lando/utils/github.py
+++ b/src/lando/utils/github.py
@@ -23,7 +23,7 @@ from simple_github import AppAuth, AppInstallationAuth
 from typing_extensions import override
 
 from lando.main.models.configuration import ConfigurationKey, ConfigurationVariable
-from lando.main.scm.helpers import PatchHelper
+from lando.main.scm.helpers import PatchHelper, PatchHelperMetadata
 from lando.utils.cache import cache_method
 from lando.utils.const import URL_USERINFO_RE
 
@@ -736,6 +736,8 @@ class PullRequestPatchHelper(PatchHelper):
             "from": f"{author_name} <{author_email}>",
             "subject": pr.title,
         }
+
+        self.metadata = PatchHelperMetadata()
 
     @classmethod
     def _get_timestamp_from_github_timestamp(cls, timestamp: str) -> str:


### PR DESCRIPTION
It doesn't contain anything useful for PRs, but is expected by the PreventSignedCommitsCheck hook.
<!--/ -+-+- DO NOT MODIFY THIS LINE - ENTER COMMIT MESSAGE ABOVE -+-+- /-->
---
Lando: [link](https://lando.moz.tools/pulls/lando/1331/)
Bugzilla: [bug 2054799](https://bugzilla.mozilla.org/show_bug.cgi?id=2054799)

:warning: This pull request has 5 warnings.
:no_entry_sign: This pull request has 2 blockers.