### PR TITLE
migrate_data: add migrate_3_bug2054804_enable_PreventSignedCommitsCheck (bug 2054804)

### DIFF
--- a/src/lando/utils/management/commands/migrate_data.py
+++ b/src/lando/utils/management/commands/migrate_data.py
@@ -130,3 +130,26 @@ class Command(BaseCommand):
             CommitMap.objects.bulk_update(batch, ["git_repo_name"])
 
         self.stdout.write("done.")
+
+    def migrate_3_bug2054804_enable_PreventSignedCommitsCheck(
+        self, ask_confirm: bool = True
+    ):
+        """Enable the PreventSignedCommitsCheck on all repos."""
+        repos = Repo.objects.all()
+
+        if not repos:
+            self.stdout.write("No repo found.")
+            raise SystemExit()
+
+        repo_names = ", ".join(repo.name for repo in repos)
+        self._get_confirmation(
+            ask_confirm, "Enabling PreventSignedCommitsCheck for: ", repo_names
+        )
+
+        for repo in repos:
+            if "PreventSignedCommitsCheck" not in repo.hooks:
+                repo.hooks.append("PreventSignedCommitsCheck")
+                repo.save()
+                self.stdout.write(f"{repo.name} ", ending="")
+
+        self.stdout.write("done.")


### PR DESCRIPTION
This is only relevant for Git repos that get synced to HgMO, but it doesn't hurt to set it for all repos for the time-being, as it is the default for new repos.

This data migration was missed when bug 1996492 was deployed.