### PR TITLE
admin: do not clear hmac secret on save (bug 2054800)

### DIFF
--- a/src/lando/main/admin.py
+++ b/src/lando/main/admin.py
@@ -343,7 +343,7 @@ class RepoAdmin(admin.ModelAdmin):
             gh_hmac_secret = self.cleaned_data.get("gh_hmac_secret", None)
             if gh_hmac_secret == "-":
                 self.instance.clear_gh_hmac_secret(save=False)
-            else:
+            elif gh_hmac_secret:
                 self.instance.set_gh_hmac_secret(gh_hmac_secret, save=False)
             return super().save(*args, **kwargs)
 


### PR DESCRIPTION

<!--/ -+-+- DO NOT MODIFY THIS LINE - ENTER COMMIT MESSAGE ABOVE -+-+- /-->
---
Lando: [link](https://lando.moz.tools/pulls/lando/1333/)
Bugzilla: [bug 2054800](https://bugzilla.mozilla.org/show_bug.cgi?id=2054800)

:warning: This pull request has 1 warning.
:no_entry_sign: This pull request has 1 blocker.