### PR TITLE
headless_api: remove headless_api.add_automationjob permission gate (bug 2055757)

### DIFF
--- a/src/lando/conftest.py
+++ b/src/lando/conftest.py
@@ -30,7 +30,6 @@ from lando.api.legacy.stacks import (
 )
 from lando.api.legacy.transplants import build_stack_assessment_state
 from lando.api.tests.mocks import PhabricatorDouble, TreeStatusDouble
-from lando.headless_api.models.automation_job import AutomationJob
 from lando.headless_api.models.tokens import ApiToken
 from lando.main.models import (
     SCM_LEVEL_1,
@@ -1295,14 +1294,6 @@ def make_superuser() -> Callable:
 
 
 @pytest.fixture
-def headless_permission():
-    content_type = ContentType.objects.get_for_model(AutomationJob)
-    return Permission.objects.get(
-        codename="add_automationjob", content_type=content_type
-    )
-
-
-@pytest.fixture
 def direct_push_permission():
     content_type = ContentType.objects.get_for_model(Profile)
     perm = Permission.objects.get(
@@ -1312,10 +1303,7 @@ def direct_push_permission():
 
 
 @pytest.fixture
-def headless_user(
-    user, headless_permission, direct_push_permission
-) -> tuple[User, str]:
-    user.user_permissions.add(headless_permission)
+def headless_user(user, direct_push_permission) -> tuple[User, str]:
     user.user_permissions.add(direct_push_permission)
     user.profile.save()
     user.save()

--- a/src/lando/headless_api/api.py
+++ b/src/lando/headless_api/api.py
@@ -415,8 +415,8 @@ def post_repo_actions(
         )
         return 400, {"details": error}
 
-    if not repo.automation_enabled:
-        error = f"Repo {repo_name} is not enabled for automation."
+    if not repo.automation_enabled or not repo.required_automation_permission:
+        error = f"Repo {repo_name} is not enabled for automation, or the required permission is not set."
         logger.info(
             error,
             extra={"user": request.user.email, "token": request.auth.token_prefix},

--- a/src/lando/headless_api/api.py
+++ b/src/lando/headless_api/api.py
@@ -80,11 +80,6 @@ class HeadlessAPIAuthentication(HttpBearer):
         except ValueError as exc:
             raise APIPermissionDenied(str(exc))
 
-        if not api_key.user.has_perm("headless_api.add_automationjob"):
-            raise APIPermissionDenied(
-                f"User {api_key.user.email} is not permitted to make automation changes."
-            )
-
         # Django-Ninja sets `request.auth` to the verified token, since
         # some APIs may have authentication without user management. Our
         # API tokens always correspond to a specific user, so set that on

--- a/src/lando/headless_api/management/commands/create_api_token.py
+++ b/src/lando/headless_api/management/commands/create_api_token.py
@@ -29,9 +29,3 @@ class Command(BaseCommand):
 
         self.stdout.write(self.style.SUCCESS(f"Token created for {email}"))
         self.stdout.write(self.style.SUCCESS(f"Token: {token}"))
-        self.stdout.write(
-            self.style.NOTICE(
-                "Once the user has received their token, they will need the\n"
-                "`headless_api.add_automationjob` permission on their user profile."
-            )
-        )

--- a/src/lando/headless_api/tests/test_automation_api.py
+++ b/src/lando/headless_api/tests/test_automation_api.py
@@ -280,18 +280,32 @@ def test_automation_job_create_hg_repo_rejected(
     )
 
 
+@pytest.mark.parametrize(
+    "automation_enabled,empty_automation_permission_required",
+    (
+        (False, False),
+        (False, True),
+        (True, True),
+    ),
+)
 @pytest.mark.django_db
 def test_automation_job_create_repo_automation_disabled(
-    client,
-    headless_user,
-    repo_mc,
+    client: Client,
+    headless_user: tuple[User, str],
+    repo_mc: Callable,
+    automation_enabled: bool,
+    empty_automation_permission_required: bool,
 ):
     user, token = headless_user
 
-    repo_mc(
+    repo = repo_mc(
         scm_type=SCMType.GIT,
-        automation_enabled=False,
+        automation_enabled=automation_enabled,
     )
+
+    if empty_automation_permission_required:
+        repo.required_automation_permission = ""
+        repo.save()
 
     body = {
         "actions": [
@@ -323,18 +337,13 @@ def test_automation_job_create_repo_automation_disabled(
     )
     assert (
         response.json()["details"]
-        == "Repo mozilla-central-git is not enabled for automation."
+        == "Repo mozilla-central-git is not enabled for automation, or the required permission is not set."
     ), "Details should indicate automation API is disabled for repo."
 
 
 @pytest.mark.parametrize(
-    "as_superuser,repo_permission_set",
-    (
-        (False, False),
-        (False, True),
-        (True, False),
-        (True, True),
-    ),
+    "as_superuser",
+    (False, True),
 )
 @pytest.mark.django_db
 def test_automation_job_create_user_no_repo_required_automation_permission(
@@ -344,7 +353,6 @@ def test_automation_job_create_user_no_repo_required_automation_permission(
     direct_push_permission: Permission,
     repo_mc: Callable,
     as_superuser: bool,
-    repo_permission_set: bool,
 ):
     user, token = headless_user
 
@@ -360,10 +368,6 @@ def test_automation_job_create_user_no_repo_required_automation_permission(
         scm_type=SCMType.GIT,
         automation_enabled=True,
     )
-
-    if not repo_permission_set:
-        repo.required_automation_permission = ""
-        repo.save()
 
     # Send a valid request.
     body = {

--- a/src/lando/headless_api/tests/test_automation_api.py
+++ b/src/lando/headless_api/tests/test_automation_api.py
@@ -327,58 +327,15 @@ def test_automation_job_create_repo_automation_disabled(
     ), "Details should indicate automation API is disabled for repo."
 
 
-@pytest.mark.django_db
-def test_automation_job_create_user_automation_disabled(
-    client, headless_user, repo_mc, headless_permission
-):
-    user, token = headless_user
-
-    # Disable automation enabled for user.
-    user.user_permissions.remove(headless_permission)
-    user.save()
-    user.profile.save()
-
-    repo_mc(
-        scm_type=SCMType.GIT,
-        automation_enabled=True,
-    )
-
-    # Send a valid request.
-    body = {
-        "actions": [
-            {
-                "action": "add-commit",
-                "content": "0",
-                "patch_format": "git-format-patch",
-            },
-            {
-                "action": "add-commit",
-                "content": "1",
-                "patch_format": "git-format-patch",
-            },
-        ],
-    }
-    response = client.post(
-        "/api/repo/mozilla-central-git",
-        data=json.dumps(body),
-        content_type="application/json",
-        headers={
-            "User-Agent": "Lando-User/testuser@example.org",
-            "Authorization": f"Bearer {token}",
-        },
-    )
-
-    assert response.status_code == 401, (
-        "User disabled for automation should return 401 status code."
-    )
-    response_json = response.json()
-    assert (
-        response_json["details"]
-        == "User testuser@example.org is not permitted to make automation changes."
-    )
-
-
-@pytest.mark.parametrize("as_superuser", (True, False))
+@pytest.mark.parametrize(
+    "as_superuser,repo_permission_set",
+    (
+        (False, False),
+        (False, True),
+        (True, False),
+        (True, True),
+    ),
+)
 @pytest.mark.django_db
 def test_automation_job_create_user_no_repo_required_automation_permission(
     client: Client,
@@ -387,6 +344,7 @@ def test_automation_job_create_user_no_repo_required_automation_permission(
     direct_push_permission: Permission,
     repo_mc: Callable,
     as_superuser: bool,
+    repo_permission_set: bool,
 ):
     user, token = headless_user
 
@@ -394,6 +352,7 @@ def test_automation_job_create_user_no_repo_required_automation_permission(
     user.user_permissions.remove(direct_push_permission)
     if as_superuser:
         user = make_superuser(user)
+
     user.save()
     user.profile.save()
 
@@ -401,6 +360,10 @@ def test_automation_job_create_user_no_repo_required_automation_permission(
         scm_type=SCMType.GIT,
         automation_enabled=True,
     )
+
+    if not repo_permission_set:
+        repo.required_automation_permission = ""
+        repo.save()
 
     # Send a valid request.
     body = {

--- a/src/lando/utils/management/commands/setup_dev.py
+++ b/src/lando/utils/management/commands/setup_dev.py
@@ -84,8 +84,6 @@ class Command(BaseCommand):
             self.stdout.write(f"Admin user ({user}) created.")
         user.is_staff = True
         user.save()
-        add_automationjob = Permission.objects.get(codename="add_automationjob")
-        user.user_permissions.add(add_automationjob)
         Group.objects.get(name=CONDUIT_ADMIN_GROUP_NAME).user_set.add(user)
         token = "a" * 128
 


### PR DESCRIPTION
We now have repo.required_automation_permission, but we add a test case to make sure the system fails closed if it's unset.

 * headless_api: remove headless_api.add_automationjob permission gate
 * headless_api: improve error reporting for missing repo.required_automation_permission

<!--/ -+-+- DO NOT MODIFY THIS LINE - ENTER COMMIT MESSAGE ABOVE -+-+- /-->
---
Lando: [link](https://lando.moz.tools/pulls/lando/1334/)
Bugzilla: [bug 2055757](https://bugzilla.mozilla.org/show_bug.cgi?id=2055757)

:warning: This pull request has 4 warnings.
:no_entry_sign: This pull request has 1 blocker.