### PR TITLE
create_environment_repo: add releng staging esr153 repo (bug 2046470)

### DIFF
--- a/src/lando/utils/management/commands/create_environment_repos.py
+++ b/src/lando/utils/management/commands/create_environment_repos.py
@@ -215,7 +215,7 @@ for branch in ["main", "autoland", "beta", "release", "esr115", "esr140", "esr15
             "push_path": "https://github.com/mozilla-releng/staging-firefox.git",
             "short_name": f"staging-firefox-{branch}",
             "required_permission": SCM_LEVEL_1,
-            "required_automation_permission": SCM_LEVEL_1,
+            "required_automation_permission": SCM_LEVEL_3,
             "automation_enabled": True,
         }
     )

--- a/src/lando/utils/management/commands/create_environment_repos.py
+++ b/src/lando/utils/management/commands/create_environment_repos.py
@@ -206,7 +206,7 @@ REPOS = {
 }
 
 # RelEng staging repo / branches - used in try pushes
-for branch in ["main", "autoland", "beta", "release", "esr115", "esr128", "esr140"]:
+for branch in ["main", "autoland", "beta", "release", "esr115", "esr140", "esr153"]:
     REPOS[Environment.staging].append(
         {
             "name": f"staging-firefox-{branch}",
@@ -215,6 +215,7 @@ for branch in ["main", "autoland", "beta", "release", "esr115", "esr128", "esr14
             "push_path": "https://github.com/mozilla-releng/staging-firefox.git",
             "short_name": f"staging-firefox-{branch}",
             "required_permission": SCM_LEVEL_1,
+            "required_automation_permission": SCM_LEVEL_1,
             "automation_enabled": True,
         }
     )


### PR DESCRIPTION
Remove esr128 (EOL), and set required_automation_permission so that the automation API can actually be used.
<!--/ -+-+- DO NOT MODIFY THIS LINE - ENTER COMMIT MESSAGE ABOVE -+-+- /-->
---
Lando: [link](https://lando.moz.tools/pulls/lando/1335/)
Bugzilla: [bug 2046470](https://bugzilla.mozilla.org/show_bug.cgi?id=2046470)

:warning: This pull request has 4 warnings.
:no_entry_sign: This pull request has 1 blocker.