### PR TITLE
revisions: block hackbot commits (bug 2054545)

### DIFF
--- a/src/lando/api/legacy/revisions.py
+++ b/src/lando/api/legacy/revisions.py
@@ -166,7 +166,7 @@ def blocker_diff_author_is_hackbot(*, diff: dict, **kwargs) -> Optional[str]:
     if hackbot_email not in emails:
         return None
 
-    return "Diff is authored by Hackbot."
+    return "Diff contains commit authored by Hackbot."
 
 
 def revision_has_needs_data_classification_tag(

--- a/src/lando/api/legacy/revisions.py
+++ b/src/lando/api/legacy/revisions.py
@@ -155,6 +155,20 @@ def blocker_diff_author_is_known(*, diff: dict, **kwargs) -> Optional[str]:
     )
 
 
+def blocker_diff_author_is_hackbot(*, diff: dict, **kwargs) -> Optional[str]:
+    """Block revisions that contain commits by Hackbot."""
+    hackbot_email = "hackbot@mozilla.tld"
+    commits = PhabricatorClient.expect(diff, "attachments", "commits", "commits")
+    if not commits:
+        return None
+
+    emails = (c.get("author", {}).get("email", "").lower() for c in commits)
+    if hackbot_email not in emails:
+        return None
+
+    return "Diff is authored by Hackbot."
+
+
 def revision_has_needs_data_classification_tag(
     revision: dict, data_policy_review_phid: str
 ) -> bool:

--- a/src/lando/api/legacy/transplants.py
+++ b/src/lando/api/legacy/transplants.py
@@ -24,6 +24,7 @@ from lando.api.legacy.reviews import (
     reviewer_identity,
 )
 from lando.api.legacy.revisions import (
+    blocker_diff_author_is_hackbot,
     blocker_diff_author_is_known,
     gather_involved_phids,
     revision_has_needs_data_classification_tag,
@@ -877,6 +878,7 @@ REVISION_BLOCKER_CHECKS = [
     blocker_latest_diffs,
     blocker_author_planned_changes,
     blocker_diff_author_is_known,
+    blocker_diff_author_is_hackbot,
     blocker_uplift_approval,
     blocker_revision_data_classification,
     # Diff-based checks.

--- a/src/lando/api/tests/mocks.py
+++ b/src/lando/api/tests/mocks.py
@@ -463,7 +463,8 @@ class PhabricatorDouble:
             author_email = author["email"]
             for c in commits:
                 c["author"]["name"] = author_name
-                c["author"]["email"] = author_name
+                c["author"]["email"] = author_email
+                c["author"]["raw"] = f"{author_name} <{author_email}>"
         elif commits:
             author_name = commits[0]["author"]["name"]
             author_email = commits[0]["author"]["email"]

--- a/src/lando/api/tests/test_revisions.py
+++ b/src/lando/api/tests/test_revisions.py
@@ -2,6 +2,7 @@ import pytest
 
 from lando.api.legacy.api import stacks
 from lando.api.legacy.revisions import (
+    blocker_diff_author_is_hackbot,
     blocker_diff_author_is_known,
     ensure_revisions_from_phabricator,
     fetch_raw_diff_and_save,
@@ -30,6 +31,29 @@ def test_check_diff_author_is_known_with_unknown_author(phabdouble):
     diff = phabdouble.api_object_for(d, attachments={"commits": True})
 
     assert blocker_diff_author_is_known(diff=diff) is not None
+
+
+@pytest.mark.parametrize(
+    "username,email,is_blocked",
+    [
+        ("Hackbot", "hackbot@mozilla.tld", True),
+        ("HaCkbOt", "hAckbOt@mOzilla.TLD", True),
+        ("Something else", "hackbot@mozilla.tld", True),
+        ("Something else", "something_else@mozilla.tld", False),
+    ],
+)
+def test_check_diff_author_is_hackbot(username, email, is_blocked, phabdouble):
+    author = phabdouble.user(username=username, email=email)
+    d = phabdouble.diff(author=author)
+    phabdouble.revision(diff=d, repo=phabdouble.repo())
+    diff = phabdouble.api_object_for(d, attachments={"commits": True})
+
+    if is_blocked:
+        assert (
+            blocker_diff_author_is_hackbot(diff=diff) == "Diff is authored by Hackbot."
+        )
+    else:
+        assert blocker_diff_author_is_hackbot(diff=diff) is None
 
 
 def test_secure_api_flag_on_public_revision_is_false(

--- a/src/lando/api/tests/test_revisions.py
+++ b/src/lando/api/tests/test_revisions.py
@@ -50,7 +50,8 @@ def test_check_diff_author_is_hackbot(username, email, is_blocked, phabdouble):
 
     if is_blocked:
         assert (
-            blocker_diff_author_is_hackbot(diff=diff) == "Diff is authored by Hackbot."
+            blocker_diff_author_is_hackbot(diff=diff)
+            == "Diff contains commit authored by Hackbot."
         )
     else:
         assert blocker_diff_author_is_hackbot(diff=diff) is None


### PR DESCRIPTION
- add blocker_diff_author_is_hackbot
- add tests
- fix phabdouble to account for user email (and raw data)
<!--/ -+-+- DO NOT MODIFY THIS LINE - ENTER COMMIT MESSAGE ABOVE -+-+- /-->
---
Lando: [link](https://lando.moz.tools/pulls/lando/1337/)
Bugzilla: [bug 2054545](https://bugzilla.mozilla.org/show_bug.cgi?id=2054545)

:warning: This pull request has 5 warnings.
:no_entry_sign: This pull request has 1 blocker.