### PR TITLE
GitSCM: add proactive git am --abort on all am failure paths (bug 2050107)

### DIFF
--- a/src/lando/main/scm/git.py
+++ b/src/lando/main/scm/git.py
@@ -279,25 +279,11 @@ class GitSCM(AbstractSCM):
             tmp_file.write(patch_bytes)
             tmp_file.flush()
 
-            try:
-                self._git_run("am", "--keep-cr", tmp_file.name, cwd=self.path)
-            except SCMException as exc:
-                try:
-                    # Clean up failed `git am`.
-                    self._git_run("am", "--abort", cwd=self.path)
-                except SCMException:
-                    pass
-
-                # Re-raise the exception from the failed `git am`.
-                raise exc
+            self._git_am(tmp_file.name)
 
     @detect_patch_conflict
     def add_diff_from_patches(self, patches: str) -> str:
         """Apply multiple patches and return the diff output."""
-        # TODO: add error handling so that if something goes wrong here,
-        # a meaningful error is stored in the landing job. This would be
-        # the same as what is done when actually applying the patches.
-        # See bug 2000268.
         with tempfile.NamedTemporaryFile(
             encoding="utf-8", mode="w+", suffix=".patch"
         ) as patch_file:
@@ -305,7 +291,7 @@ class GitSCM(AbstractSCM):
             patch_file.flush()
 
             base_commit_sha = self._git_run("rev-parse", "HEAD", cwd=self.path)
-            self._git_run("am", "--keep-cr", "--reject", patch_file.name, cwd=self.path)
+            self._git_am(patch_file.name, keep_rejects=True)
 
             # Write to a temp file instead of stdout so the diff stays out of command logs.
             with tempfile.NamedTemporaryFile(suffix=".diff") as diff_file:
@@ -328,6 +314,25 @@ class GitSCM(AbstractSCM):
             diff = diff_bytes.decode("latin-1")
 
         return diff.lstrip()
+
+    def _git_am(self, diff_name: str, *, keep_rejects: bool = False):
+        """Run git am with a fallback to clean-up on error."""
+        command = ["am", "--keep-cr"]
+        if keep_rejects:
+            command.append("--reject")
+        command.append(diff_name)
+
+        try:
+            self._git_run(*command, cwd=self.path)
+        except SCMException as exc:
+            try:
+                # Clean up failed `git am`.
+                self._git_run("am", "--abort", cwd=self.path)
+            except SCMException:
+                pass
+
+            # Re-raise the exception from the failed `git am`.
+            raise exc
 
     @override
     def get_patch(self, revision_id: str) -> str | None:

--- a/src/lando/main/scm/git.py
+++ b/src/lando/main/scm/git.py
@@ -265,16 +265,6 @@ class GitSCM(AbstractSCM):
     @detect_patch_conflict
     def apply_patch_git(self, patch_bytes: bytes):
         """Apply the Git patch, provided as encoded bytes."""
-        try:
-            # Clean up existing failed `git am`.
-            self._git_run("am", "--abort", cwd=self.path)
-        except SCMException as exc:
-            # Command will return exit code 1 if there is no failed `git am` in progress.
-            # Look for the expected error message and ignore the exception.
-            if "Resolve operation not in progress" not in exc.err:
-                # Real error, re-raise the exception.
-                raise exc
-
         with tempfile.NamedTemporaryFile(mode="wb", suffix=".patch") as tmp_file:
             tmp_file.write(patch_bytes)
             tmp_file.flush()

--- a/src/lando/main/tests/test_git.py
+++ b/src/lando/main/tests/test_git.py
@@ -415,25 +415,6 @@ def test_GitSCM_apply_patch_git_aborts_on_failure(
         "`rebase-apply` dir was not cleaned up after failed git am"
     )
 
-    # Create `rebase-apply` directory.
-    rebase_apply.mkdir()
-
-    # Create a good patch.
-    good_patch_str = git_patch()
-    good_patch_b64 = base64.b64encode(good_patch_str.encode("utf-8")).decode("ascii")
-    good_patch_bytes = base64.b64decode(good_patch_b64)
-
-    # Apply a good patch with failed `git am` state present.
-    scm.apply_patch_git(good_patch_bytes)
-
-    # Ensure the `rebase-apply` directory is gone.
-    assert not rebase_apply.exists(), (
-        "`rebase-apply` dir was not cleaned up after failed git am"
-    )
-
-    commit = scm.describe_commit()
-    assert commit.hash, "Valid patch did not land after recovering from failure"
-
 
 DIFF_WITH_IGNORED_JSON = """\
 diff --git a/ignored.json b/ignored.json
@@ -1549,7 +1530,7 @@ def test_GitSCM_breakdown_from_conflicts_is_pure(git_repo: Path):
                 "commit_date": "",
             },
         ),
-        ("apply_patch_git", {"patch_bytes": ""}),
+        ("apply_patch_git", {"patch_bytes": b""}),
     ),
 )
 def test_GitSCM__detect_patch_conflict(


### PR DESCRIPTION
* GitSCM: add proactive `git am --abort` on all `am` failure paths
 * GitSCM: remove defensive `git am --abort`
<!--/ -+-+- DO NOT MODIFY THIS LINE - ENTER COMMIT MESSAGE ABOVE -+-+- /-->
---
Lando: [link](https://lando.moz.tools/pulls/lando/1339/)
Bugzilla: [bug 2050107](https://bugzilla.mozilla.org/show_bug.cgi?id=2050107)

:warning: This pull request has 3 warnings.
:no_entry_sign: This pull request has 1 blocker.