### PR TITLE
repo: make commit_flags editable and default to DONTBUILD (bug 2056752)

### DIFF
--- a/src/lando/main/admin.py
+++ b/src/lando/main/admin.py
@@ -371,7 +371,6 @@ class RepoAdmin(admin.ModelAdmin):
     inlines = (RepoWorkersInline,)
     readonly_fields = (
         "gh_hmac_secret_is_set",
-        "commit_flags",
         "system_path",
         "scm_type",
         "created_at",

--- a/src/lando/main/models/repo.py
+++ b/src/lando/main/models/repo.py
@@ -89,6 +89,15 @@ def get_default_hooks() -> list[str]:
     ]
 
 
+def get_default_commit_flags() -> list[list[str]]:
+    return [
+        [
+            'DONTBUILD',
+            'Should be used only for trivial changes (typo, comment changes, documentation changes, etc.) where the risk of introducing a new bug is close to none.'
+        ],
+    ]
+
+
 class Repo(CryptographyMixin, BaseModel):
     """Represents the configuration of a particular repo."""
 
@@ -217,7 +226,13 @@ class Repo(CryptographyMixin, BaseModel):
         size=2,
         blank=True,
         null=True,
-        default=None,
+        default=get_default_commit_flags,
+        help_text=(
+            "List of commit flags that can be appended to the commit at landing time. "
+            "Each commit flag is a list of two string: the flag itself, "
+            "and a description to be shown in the UI. For example, "
+            "`['DONTBUILD', 'Should be used only for trivial changes (typo, comment changes, documentation changes, etc.) where the risk of introducing a new bug is close to none.']`"
+        ),
     )
     force_push = models.BooleanField(default=False)
     is_phabricator_repo = models.BooleanField(default=True)


### PR DESCRIPTION

<!--/ -+-+- DO NOT MODIFY THIS LINE - ENTER COMMIT MESSAGE ABOVE -+-+- /-->
---
Lando: [link](https://lando.moz.tools/pulls/lando/1341/)
Bugzilla: [bug 2056752](https://bugzilla.mozilla.org/show_bug.cgi?id=2056752)

:warning: This pull request has 3 warnings.
:no_entry_sign: This pull request has 2 blockers.