### PR TITLE
dependabot: add required `dependency-name` to the npm ignore rule (bug 2058371)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,7 +23,8 @@ updates:
       allow:
           - dependency-type: all
       ignore:
-          - update-types:
-                # Our package.json allows semver-compatible versions (with ^).
-                # This means no major bumps.
+          # Our package.json allows semver-compatible versions (with ^).
+          # This means no major bumps.
+          - dependency-name: "*"
+            update-types:
                 - "version-update:semver-major"


### PR DESCRIPTION
Each entry under `ignore` must specify `dependency-name`, so the config has
failed validation since the rule was added. Use `"*"` to keep applying the
major-version ignore to every npm dependency.
<!--/ -+-+- DO NOT MODIFY THIS LINE - ENTER COMMIT MESSAGE ABOVE -+-+- /-->
---
Lando: [link](https://lando.moz.tools/pulls/lando/1353/)
Bugzilla: [bug 2058371](https://bugzilla.mozilla.org/show_bug.cgi?id=2058371)

:warning: This pull request has 1 warning.
:no_entry_sign: This pull request has 2 blockers.