### PR TITLE
views: fix key error with empty warnings  (bug 2059434)

### DIFF
--- a/src/lando/api/tests/test_views.py
+++ b/src/lando/api/tests/test_views.py
@@ -576,7 +576,24 @@ class TestViewsPullRequestUpdateWebHook:
 @pytest.mark.parametrize(
     "warnings_1, warnings_2, expected_status, expected_response",
     [
+        ([], [], 201, b""),
         (["warning-1", "warning-2"], ["warning-1", "warning-2"], 201, b""),
+        (
+            [],
+            ["warning-1", "warning-2"],
+            400,
+            [
+                "The warnings present when the request was constructed have changed. Please acknowledge the new warnings and try again."
+            ],
+        ),
+        (
+            ["warning-1", "warning-2"],
+            [],
+            400,
+            [
+                "The warnings present when the request was constructed have changed. Please acknowledge the new warnings and try again."
+            ],
+        ),
         (
             ["warning-1", "warning-2"],
             ["warning-3", "warning-4"],

--- a/src/lando/api/views.py
+++ b/src/lando/api/views.py
@@ -288,8 +288,9 @@ class LandingJobPullRequestAPIView(PullRequestAPIView):
             def clean(self):
 
                 cleaned_data = self.cleaned_data
-                new_warnings = cleaned_data["new_warnings"]
-                old_warnings = cleaned_data["old_warnings"]
+                new_warnings = cleaned_data["new_warnings"] or []
+                old_warnings = cleaned_data["old_warnings"] or []
+
                 if sorted(new_warnings) != sorted(old_warnings):
                     self.errors["warnings"] = [
                         "The warnings present when the request was constructed have changed. "
@@ -299,8 +300,8 @@ class LandingJobPullRequestAPIView(PullRequestAPIView):
                 return cleaned_data
 
             head_sha = forms.CharField()
-            new_warnings = forms.JSONField()
-            old_warnings = forms.JSONField()
+            new_warnings = forms.JSONField(required=False)
+            old_warnings = forms.JSONField(required=False)
             # TODO: use this for verification later, see bug 1996571.
             # base_ref = forms.CharField()
 
@@ -309,16 +310,15 @@ class LandingJobPullRequestAPIView(PullRequestAPIView):
         warnings_and_blockers = generate_warnings_and_blockers(
             self.target_repo, self.pull_request, request
         )
-        new_warnings = warnings_and_blockers["warnings"]
 
         if blockers := warnings_and_blockers["blockers"]:
             return JsonResponse({"errors": blockers}, status=400)
 
         data = json.loads(request.body)
         # add new warnings to the data so that the form can validate that they match the old warnings
+        new_warnings = warnings_and_blockers["warnings"]
         data["new_warnings"] = new_warnings
         form = Form(data)
-
         if not form.is_valid():
             return JsonResponse(
                 {"errors": form.errors, "new_warnings": new_warnings}, status=400


### PR DESCRIPTION

<!--/ -+-+- DO NOT MODIFY THIS LINE - ENTER COMMIT MESSAGE ABOVE -+-+- /-->

---

Lando: [link](https://lando.moz.tools/pulls/lando/1405/)
Bugzilla: [bug 2059434](https://bugzilla.mozilla.org/show_bug.cgi?id=2059434)

:warning: This pull request has 6 warnings.
:no_entry_sign: This pull request has 1 blocker.