### PR TITLE
revisions: add author override functionality (bug 2055953)

### DIFF
--- a/src/lando/api/legacy/api/transplants.py
+++ b/src/lando/api/legacy/api/transplants.py
@@ -228,8 +228,9 @@ def post(phab: PhabricatorClient, user: User, data: dict) -> tuple[dict[str, int
         # TODO: it would be more ideal if this is a validation error, however, we do not have the
         # necessary information at the time of form submission to determine this without performing
         # additional redundant processing outside the form.
-        raise ValueError(
-            "Mailbox values should be present if and only if disallowed authors are persent."
+        raise LegacyAPIException(
+            400,
+            "Mailbox values should be present if and only if disallowed authors are present.",
         )
 
     if assessment.warnings:
@@ -311,13 +312,14 @@ def post(phab: PhabricatorClient, user: User, data: dict) -> tuple[dict[str, int
             flags,
         )[1]
 
-        args = (phab, revision["id"], diff, commit_message)
-        kwargs = {}
-
         if diff_has_disallowed_author(diff):
-            kwargs["mailbox"] = mailbox
-
-        lando_revision = fetch_raw_diff_and_save(*args, **kwargs)
+            lando_revision = fetch_raw_diff_and_save(
+                phab, revision["id"], diff, commit_message, mailbox=mailbox
+            )
+        else:
+            lando_revision = fetch_raw_diff_and_save(
+                phab, revision["id"], diff, commit_message
+            )
 
         revision_reviewers[lando_revision.id] = get_approved_by_ids(
             phab,

--- a/src/lando/api/legacy/api/transplants.py
+++ b/src/lando/api/legacy/api/transplants.py
@@ -53,7 +53,7 @@ from lando.main.models import (
     Repo,
     add_revisions_to_job,
 )
-from lando.main.support import LegacyAPIException
+from lando.main.support import LegacyAPIException, diff_has_disallowed_author
 from lando.utils.phabricator import PhabricatorClient
 from lando.utils.tasks import admin_remove_phab_project
 
@@ -218,6 +218,20 @@ def post(phab: PhabricatorClient, user: User, data: dict) -> tuple[dict[str, int
         )
         raise LegacyAPIException(400, error_message)
 
+    mailbox = data.get("mailbox", None)
+    has_disallowed_author_diffs = any(
+        diff_has_disallowed_author(diff) for revision, diff in to_land
+    )
+    if (has_disallowed_author_diffs and not mailbox) or (
+        not has_disallowed_author_diffs and mailbox
+    ):
+        # TODO: it would be more ideal if this is a validation error, however, we do not have the
+        # necessary information at the time of form submission to determine this without performing
+        # additional redundant processing outside the form.
+        raise ValueError(
+            "Mailbox values should be present if and only if disallowed authors are persent."
+        )
+
     if assessment.warnings:
         # Log any warnings that were acknowledged, for auditing.
         logger.info(
@@ -296,9 +310,14 @@ def post(phab: PhabricatorClient, user: User, data: dict) -> tuple[dict[str, int
             ),
             flags,
         )[1]
-        lando_revision = fetch_raw_diff_and_save(
-            phab, revision["id"], diff, commit_message
-        )
+
+        args = (phab, revision["id"], diff, commit_message)
+        kwargs = {}
+
+        if diff_has_disallowed_author(diff):
+            kwargs["mailbox"] = mailbox
+
+        lando_revision = fetch_raw_diff_and_save(*args, **kwargs)
 
         revision_reviewers[lando_revision.id] = get_approved_by_ids(
             phab,

--- a/src/lando/api/legacy/revisions.py
+++ b/src/lando/api/legacy/revisions.py
@@ -268,7 +268,7 @@ def fetch_raw_diff_and_save(
     revision_id: int,
     diff: dict,
     commit_message: str,
-    mailbox: tuple[str] | None = None,
+    mailbox: tuple[str, str] | None = None,
 ) -> Revision:
     """Fetch the raw diff from Phabricator and save a `Revision` record.
 

--- a/src/lando/api/legacy/revisions.py
+++ b/src/lando/api/legacy/revisions.py
@@ -280,6 +280,7 @@ def fetch_raw_diff_and_save(
         revision_id: The integer revision ID (e.g. 123 for D123).
         diff: A Phabricator diff dict with the `commits` attachment.
         commit_message: The full commit message to embed in the patch.
+        mailbox: A tuple consisting of the author name and email.
     """
     diff_id = PhabricatorClient.expect(diff, "id")
     author_name, author_email = mailbox or select_diff_author(diff)

--- a/src/lando/api/legacy/revisions.py
+++ b/src/lando/api/legacy/revisions.py
@@ -155,20 +155,6 @@ def blocker_diff_author_is_known(*, diff: dict, **kwargs) -> Optional[str]:
     )
 
 
-def blocker_diff_author_is_hackbot(*, diff: dict, **kwargs) -> Optional[str]:
-    """Block revisions that contain commits by Hackbot."""
-    hackbot_email = "hackbot@mozilla.tld"
-    commits = PhabricatorClient.expect(diff, "attachments", "commits", "commits")
-    if not commits:
-        return None
-
-    emails = (c.get("author", {}).get("email", "").lower() for c in commits)
-    if hackbot_email not in emails:
-        return None
-
-    return "Diff contains commit authored by Hackbot."
-
-
 def revision_has_needs_data_classification_tag(
     revision: dict, data_policy_review_phid: str
 ) -> bool:
@@ -282,6 +268,7 @@ def fetch_raw_diff_and_save(
     revision_id: int,
     diff: dict,
     commit_message: str,
+    mailbox: tuple[str] | None = None,
 ) -> Revision:
     """Fetch the raw diff from Phabricator and save a `Revision` record.
 
@@ -295,7 +282,7 @@ def fetch_raw_diff_and_save(
         commit_message: The full commit message to embed in the patch.
     """
     diff_id = PhabricatorClient.expect(diff, "id")
-    author_name, author_email = select_diff_author(diff)
+    author_name, author_email = mailbox or select_diff_author(diff)
     base_revision = get_base_revision_from_diff(diff)
 
     logger.debug("Fetching raw diff for D%s (diff %s).", revision_id, diff_id)

--- a/src/lando/api/legacy/transplants.py
+++ b/src/lando/api/legacy/transplants.py
@@ -24,7 +24,6 @@ from lando.api.legacy.reviews import (
     reviewer_identity,
 )
 from lando.api.legacy.revisions import (
-    blocker_diff_author_is_hackbot,
     blocker_diff_author_is_known,
     gather_involved_phids,
     revision_has_needs_data_classification_tag,
@@ -46,7 +45,7 @@ from lando.main.models import (
     LandingJob,
     Repo,
 )
-from lando.main.support import LegacyAPIException
+from lando.main.support import DISALLOWED_AUTHOR_EMAILS, LegacyAPIException
 from lando.utils.landing_checks import (
     DiffAssessor,
     PreventNSPRNSSCheck,
@@ -331,6 +330,20 @@ class RevisionWarningCheck:
             )
 
         return wrapped
+
+
+@RevisionWarningCheck("Commit contains author that will be modified before landing.")
+def warning_diff_author_is_hackbot(
+    revision: dict, diff: dict, stack_state: StackAssessmentState
+) -> str | None:
+    """Warn when revisions contain commits by disallowed authors (e.g., Hackbot)."""
+    commits = PhabricatorClient.expect(diff, "attachments", "commits", "commits")
+    if not commits:
+        return None
+
+    emails = (c.get("author", {}).get("email", "").lower() for c in commits)
+    if set(emails).intersection(DISALLOWED_AUTHOR_EMAILS):
+        return "Diff contains commit authored by disallowed email."
 
 
 @RevisionWarningCheck("Has a review intended to block landing.")
@@ -878,7 +891,6 @@ REVISION_BLOCKER_CHECKS = [
     blocker_latest_diffs,
     blocker_author_planned_changes,
     blocker_diff_author_is_known,
-    blocker_diff_author_is_hackbot,
     blocker_uplift_approval,
     blocker_revision_data_classification,
     # Diff-based checks.
@@ -901,6 +913,7 @@ WARNING_CHECKS = [
     warning_wip_commit_message,
     warning_unresolved_comments,
     warning_multiple_authors,
+    warning_diff_author_is_hackbot,
 ]
 
 

--- a/src/lando/api/legacy/transplants.py
+++ b/src/lando/api/legacy/transplants.py
@@ -9,6 +9,7 @@ from typing import Any, Callable, Self
 
 import networkx as nx
 import rs_parsepatch
+from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.cache import cache
 
@@ -45,7 +46,7 @@ from lando.main.models import (
     LandingJob,
     Repo,
 )
-from lando.main.support import DISALLOWED_AUTHOR_EMAILS, LegacyAPIException
+from lando.main.support import LegacyAPIException
 from lando.utils.landing_checks import (
     DiffAssessor,
     PreventNSPRNSSCheck,
@@ -341,8 +342,8 @@ def warning_diff_author_is_hackbot(
     if not commits:
         return None
 
-    emails = (c.get("author", {}).get("email", "").lower() for c in commits)
-    if set(emails).intersection(DISALLOWED_AUTHOR_EMAILS):
+    emails = (c.get("author", {}).get("email", "").strip().lower() for c in commits)
+    if set(emails).intersection(settings.DISALLOWED_AUTHOR_EMAILS):
         return "Diff contains commit authored by disallowed email."
 
 

--- a/src/lando/api/tests/conftest.py
+++ b/src/lando/api/tests/conftest.py
@@ -15,7 +15,6 @@ from django.test import Client
 
 from lando.api.legacy.projects import (
     CHECKIN_PROJ_SLUG,
-    RELMAN_PROJECT_SLUG,
     SEC_APPROVAL_PROJECT_SLUG,
     SEC_PROJ_SLUG,
 )
@@ -165,14 +164,6 @@ def sec_approval_project(phabdouble):
 
 
 @pytest.fixture
-def release_management_project(phabdouble):
-    return phabdouble.project(
-        RELMAN_PROJECT_SLUG,
-        attachments={"members": {"members": [{"phid": "PHID-USER-1"}]}},
-    )
-
-
-@pytest.fixture
 def versionfile(tmpdir):
     """Provide a temporary version.json on disk."""
     v = tmpdir.mkdir("app").join("version.json")
@@ -314,12 +305,6 @@ def user_linked_to_phab(phabdouble, user):
     user.profile.phabricator_phid = phab_user["phid"]
     user.profile.save()
     return phab_user
-
-
-@pytest.fixture
-def authenticated_client(user, user_plaintext_password, client):
-    client.login(username=user.username, password=user_plaintext_password)
-    return client
 
 
 @pytest.fixture

--- a/src/lando/api/tests/test_revisions.py
+++ b/src/lando/api/tests/test_revisions.py
@@ -2,7 +2,6 @@ import pytest
 
 from lando.api.legacy.api import stacks
 from lando.api.legacy.revisions import (
-    blocker_diff_author_is_hackbot,
     blocker_diff_author_is_known,
     ensure_revisions_from_phabricator,
     fetch_raw_diff_and_save,
@@ -10,6 +9,7 @@ from lando.api.legacy.revisions import (
     revision_is_secure,
     revision_needs_testing_tag,
 )
+from lando.api.legacy.transplants import warning_diff_author_is_hackbot
 from lando.main.models.revision import Revision
 
 pytestmark = pytest.mark.usefixtures("docker_env_vars")
@@ -34,7 +34,7 @@ def test_check_diff_author_is_known_with_unknown_author(phabdouble):
 
 
 @pytest.mark.parametrize(
-    "username,email,is_blocked",
+    "username,email,has_warning",
     [
         ("Hackbot", "hackbot@mozilla.tld", True),
         ("HaCkbOt", "hAckbOt@mOzilla.TLD", True),
@@ -42,19 +42,27 @@ def test_check_diff_author_is_known_with_unknown_author(phabdouble):
         ("Something else", "something_else@mozilla.tld", False),
     ],
 )
-def test_check_diff_author_is_hackbot(username, email, is_blocked, phabdouble):
+def test_check_diff_author_is_hackbot(username, email, has_warning, phabdouble):
     author = phabdouble.user(username=username, email=email)
     d = phabdouble.diff(author=author)
-    phabdouble.revision(diff=d, repo=phabdouble.repo())
+    r = phabdouble.revision(diff=d, repo=phabdouble.repo())
     diff = phabdouble.api_object_for(d, attachments={"commits": True})
+    revision = phabdouble.api_object_for(r)
 
-    if is_blocked:
+    if has_warning:
         assert (
-            blocker_diff_author_is_hackbot(diff=diff)
-            == "Diff contains commit authored by Hackbot."
+            warning_diff_author_is_hackbot(
+                revision=revision, diff=diff, stack_state=None
+            ).display
+            == "Commit contains author that will be modified before landing."
         )
     else:
-        assert blocker_diff_author_is_hackbot(diff=diff) is None
+        assert (
+            warning_diff_author_is_hackbot(
+                revision=revision, diff=diff, stack_state=None
+            )
+            is None
+        )
 
 
 def test_secure_api_flag_on_public_revision_is_false(

--- a/src/lando/conftest.py
+++ b/src/lando/conftest.py
@@ -1232,13 +1232,16 @@ def scm_user() -> Callable:
         group_perms: list[Permission] | None = None,
     ) -> User:
         """Return a user with the selected Permissions and password."""
+        email = "testuser@example.org"
         user = User.objects.create_user(
             username="test_user",
             password=password,
-            email="testuser@example.org",
+            email=email,
         )
 
-        user.profile = Profile(user=user, userinfo={"name": "test user"})
+        user.profile = Profile(
+            user=user, userinfo={"name": "test user", "email": email}
+        )
 
         for permission in perms:
             user.user_permissions.add(permission)
@@ -1315,6 +1318,14 @@ def headless_user(user, direct_push_permission) -> tuple[User, str]:
 @pytest.fixture
 def needs_data_classification_project(phabdouble):
     return phabdouble.project(NEEDS_DATA_CLASSIFICATION_SLUG)
+
+
+@pytest.fixture
+def release_management_project(phabdouble):
+    return phabdouble.project(
+        RELMAN_PROJECT_SLUG,
+        attachments={"members": {"members": [{"phid": "PHID-USER-1"}]}},
+    )
 
 
 @pytest.fixture
@@ -1744,3 +1755,9 @@ def pull_request_data(update_dict) -> Callable:
         return data
 
     return _pull_request_data
+
+
+@pytest.fixture
+def authenticated_client(user, user_plaintext_password, client):
+    client.login(username=user.username, password=user_plaintext_password)
+    return client

--- a/src/lando/main/support.py
+++ b/src/lando/main/support.py
@@ -1,9 +1,8 @@
+from django.conf import settings
 from django.core.files.storage import storages
 from storages.backends.gcloud import GoogleCloudStorage
 
 from lando.api.legacy.revisions import select_diff_author
-
-DISALLOWED_AUTHOR_EMAILS = ("hackbot@mozilla.tld",)
 
 
 class CachedGoogleCloudStorage(GoogleCloudStorage):
@@ -38,12 +37,20 @@ class LegacyAPIException(Exception):
 
 
 def get_revisions_with_disallowed_authors(revisions: dict[str, dict]) -> list[dict]:
+    """Return a list of revisions with disallowed authors."""
     return [r for r in revisions.values() if revision_has_disallowed_author(r)]
 
 
 def revision_has_disallowed_author(revision: dict) -> bool:
-    return revision["diff"]["author"]["email"].lower() in DISALLOWED_AUTHOR_EMAILS
+    """Return True if a revision has a disallowed author, otherwise False."""
+    return (
+        revision["diff"]["author"]["email"].strip().lower()
+        in settings.DISALLOWED_AUTHOR_EMAILS
+    )
 
 
 def diff_has_disallowed_author(diff: dict) -> bool:
-    return select_diff_author(diff)[1] in DISALLOWED_AUTHOR_EMAILS
+    """Return True if a diff has a disallowed author, otherwise False."""
+    return (
+        select_diff_author(diff)[1].strip().lower() in settings.DISALLOWED_AUTHOR_EMAILS
+    )

--- a/src/lando/main/support.py
+++ b/src/lando/main/support.py
@@ -1,6 +1,10 @@
 from django.core.files.storage import storages
 from storages.backends.gcloud import GoogleCloudStorage
 
+from lando.api.legacy.revisions import select_diff_author
+
+DISALLOWED_AUTHOR_EMAILS = ("hackbot@mozilla.tld",)
+
 
 class CachedGoogleCloudStorage(GoogleCloudStorage):
     """
@@ -31,3 +35,15 @@ class LegacyAPIException(Exception):
         }
         if self.extra:
             self.json_detail.update(self.extra)
+
+
+def get_revisions_with_disallowed_authors(revisions: dict[str, dict]) -> list[dict]:
+    return [r for r in revisions.values() if revision_has_disallowed_author(r)]
+
+
+def revision_has_disallowed_author(revision: dict) -> bool:
+    return revision["diff"]["author"]["email"].lower() in DISALLOWED_AUTHOR_EMAILS
+
+
+def diff_has_disallowed_author(diff: dict) -> bool:
+    return select_diff_author(diff)[1] in DISALLOWED_AUTHOR_EMAILS

--- a/src/lando/main/support.py
+++ b/src/lando/main/support.py
@@ -37,12 +37,18 @@ class LegacyAPIException(Exception):
 
 
 def get_revisions_with_disallowed_authors(revisions: dict[str, dict]) -> list[dict]:
-    """Return a list of revisions with disallowed authors."""
+    """Return a list of revisions with disallowed authors.
+
+    An author is disallowed if it is present in the DISALLOWED_AUTHOR_EMAILS setting.
+    """
     return [r for r in revisions.values() if revision_has_disallowed_author(r)]
 
 
 def revision_has_disallowed_author(revision: dict) -> bool:
-    """Return True if a revision has a disallowed author, otherwise False."""
+    """Return True if a revision has a disallowed author, otherwise False.
+
+    An author is disallowed if it is present in the DISALLOWED_AUTHOR_EMAILS setting.
+    """
     return (
         revision["diff"]["author"]["email"].strip().lower()
         in settings.DISALLOWED_AUTHOR_EMAILS
@@ -50,7 +56,10 @@ def revision_has_disallowed_author(revision: dict) -> bool:
 
 
 def diff_has_disallowed_author(diff: dict) -> bool:
-    """Return True if a diff has a disallowed author, otherwise False."""
+    """Return True if a diff has a disallowed author, otherwise False.
+
+    An author is disallowed if it is present in the DISALLOWED_AUTHOR_EMAILS setting.
+    """
     return (
-        select_diff_author(diff)[1].strip().lower() in settings.DISALLOWED_AUTHOR_EMAILS
-    )
+        select_diff_author(diff)[1] or ""
+    ).strip().lower() in settings.DISALLOWED_AUTHOR_EMAILS

--- a/src/lando/settings.py
+++ b/src/lando/settings.py
@@ -352,3 +352,5 @@ AUDITLOG_EXCLUDE_TRACKING_FIELDS = (
     "created_at",
     "updated_at",
 )
+
+DISALLOWED_AUTHOR_EMAILS = ("hackbot@mozilla.tld",)

--- a/src/lando/ui/jinja2/stack/partials/landing-preview.html
+++ b/src/lando/ui/jinja2/stack/partials/landing-preview.html
@@ -8,6 +8,21 @@
         {{ blocker|escape_html|linkify_faq|safe }}
     </div>
 {% elif series %}
+    {% if revisions_with_disallowed_authors %}
+        <span class="has-text-danger">Commit Author must be changed before landing. This will only affect revisions with disallowed authors (
+            {% for _rev in revisions_with_disallowed_authors %}{{ _rev.id|linkify_phabricator_revision_ids|safe }}{% endfor %}
+        ).</span>
+        <div>
+            <div class="field">
+                <label class="label">New Commit Author Name</label>
+                <div class="control">{{ form.author_name }}</div>
+            </div>
+            <div class="field">
+                <label class="label">New Commit Author Email</label>
+                <div class="control">{{ form.author_email }}</div>
+            </div>
+        </div>
+    {% endif %}
     <h3 class="StackPage-landingPreview-sectionLabel">
         Landing To: &nbsp;
         <a class="StackPage-landingPreview-landingTo"

--- a/src/lando/ui/jinja2/stack/partials/landing-preview.html
+++ b/src/lando/ui/jinja2/stack/partials/landing-preview.html
@@ -10,7 +10,7 @@
 {% elif series %}
     {% if revisions_with_disallowed_authors %}
         <span class="has-text-danger">Commit Author must be changed before landing. This will only affect revisions with disallowed authors (
-            {% for _rev in revisions_with_disallowed_authors %}{{ _rev.id|linkify_phabricator_revision_ids|safe }}{% endfor %}
+            {%- for _rev in revisions_with_disallowed_authors %}{{ _rev.id|linkify_phabricator_revision_ids|safe }}{{ " " if not loop.last else "" }}{% endfor -%}
         ).</span>
         <div>
             <div class="field">

--- a/src/lando/ui/jinja2/stack/stack.html
+++ b/src/lando/ui/jinja2/stack/stack.html
@@ -104,15 +104,15 @@
             <div class="StackPage-landingPreview modal">
                 <div class="modal-background"></div>
                 <div class="modal-card">
-                    <header class="modal-card-head">
-                        <p class="modal-card-title">Preview landing</p>
-                        <button class="StackPage-landingPreview-close delete" aria-label="close"></button>
-                    </header>
-                    <section class="modal-card-body">
-                        {% include "stack/partials/landing-preview.html" %}
-                    </section>
-                    <footer class="modal-card-foot">
-                        <form class="StackPage-form" action="" method="post">
+                    <form class="StackPage-form" action="" method="post">
+                        <header class="modal-card-head">
+                            <p class="modal-card-title">Preview landing</p>
+                            <button class="StackPage-landingPreview-close delete" aria-label="close"></button>
+                        </header>
+                        <section class="modal-card-body">
+                            {% include "stack/partials/landing-preview.html" %}
+                        </section>
+                        <footer class="modal-card-foot">
                             {{ csrf_input }}
                             {{ form.landing_path }}
                             {{ form.confirmation_token }}
@@ -126,8 +126,8 @@
                                 {% if target_repo.is_git %}@{{ target_repo.default_branch }}{% endif %}
                             </button>
                             <button class="StackPage-landingPreview-close button">Cancel</button>
-                        </form>
-                    </footer>
+                        </footer>
+                    </form>
                 </div>
             </div>
         {% endif %}

--- a/src/lando/ui/legacy/forms.py
+++ b/src/lando/ui/legacy/forms.py
@@ -1,5 +1,8 @@
+from typing import Any
+
 from django import forms
 from django.contrib.auth.models import User
+from django.core.exceptions import ValidationError
 from django.forms.widgets import RadioSelect
 from django.utils import timezone
 
@@ -10,14 +13,68 @@ from lando.main.models.uplift import (
     UpliftTargetSelectionMethod,
     YesNoChoices,
 )
+from lando.main.support import DISALLOWED_AUTHOR_EMAILS
 
 
 class TransplantRequestForm(forms.Form):
+    def validate_author(value):
+        if value in DISALLOWED_AUTHOR_EMAILS:
+            raise ValidationError("The email provided is not allowed")
+
     landing_path = forms.JSONField(widget=forms.widgets.HiddenInput)
     confirmation_token = forms.CharField(
         widget=forms.widgets.HiddenInput, required=False
     )
     flags = forms.JSONField(widget=forms.widgets.HiddenInput, required=False)
+
+    # Mailbox fields.
+    author_name = forms.CharField(
+        required=False, widget=forms.TextInput(attrs={"class": "input"})
+    )
+
+    author_email = forms.EmailField(
+        required=False,
+        widget=forms.TextInput(attrs={"class": "input"}),
+        validators=[validate_author],
+    )
+
+    def clean(self) -> dict[str, Any]:
+        """
+        Peform custom validation on mailbox input.
+
+        The author name and email fields are optional, however, if one is provided
+        then the other must be provided as well. This is how the mailbox value is
+        determined and set in cleaned data at the end of this process.
+
+        """
+        cleaned_data = super().clean()
+
+        # If a validation error was raised on one of the fields, it's important to
+        # retain those original errors.
+        self.errors["author_email"] = self.errors.get("author_email", [])
+        self.errors["author_name"] = self.errors.get("author_name", [])
+
+        name, email = cleaned_data.get("author_name"), cleaned_data.get("author_email")
+
+        if name and not email:
+            self.errors["author_email"].append("This field is required.")
+        if email and not name:
+            self.errors["author_name"].append("This field is required.")
+
+        if name and email:
+            cleaned_data["mailbox"] = (name, email)
+            del cleaned_data["author_name"]
+            del cleaned_data["author_email"]
+        else:
+            cleaned_data["mailbox"] = None
+
+        # This removes the error entries from these fields, if no errors were found.
+        if not self.errors["author_email"]:
+            del self.errors["author_email"]
+        if not self.errors["author_name"]:
+            del self.errors["author_name"]
+
+        return cleaned_data
 
 
 class UpliftAssessmentForm(forms.ModelForm):

--- a/src/lando/ui/legacy/forms.py
+++ b/src/lando/ui/legacy/forms.py
@@ -41,8 +41,7 @@ class TransplantRequestForm(forms.Form):
         return value
 
     def clean(self) -> dict[str, Any]:
-        """
-        Peform custom validation on mailbox input.
+        """Perform custom validation on mailbox input.
 
         The author name and email fields are optional, however, if one is provided
         then the other must be provided as well. This is how the mailbox value is
@@ -53,15 +52,12 @@ class TransplantRequestForm(forms.Form):
 
         # If a validation error was raised on one of the fields, it's important to
         # retain those original errors.
-        self.errors["author_email"] = self.errors.get("author_email", [])
-        self.errors["author_name"] = self.errors.get("author_name", [])
-
         name, email = cleaned_data.get("author_name"), cleaned_data.get("author_email")
 
         if name and not email:
-            self.errors["author_email"].append("This field is required.")
+            self.add_error("author_email", "This field is required.")
         if email and not name:
-            self.errors["author_name"].append("This field is required.")
+            self.add_error("author_name", "This field is required.")
 
         if name and email:
             cleaned_data["mailbox"] = (name, email)
@@ -69,12 +65,6 @@ class TransplantRequestForm(forms.Form):
             del cleaned_data["author_email"]
         else:
             cleaned_data["mailbox"] = None
-
-        # This removes the error entries from these fields, if no errors were found.
-        if not self.errors["author_email"]:
-            del self.errors["author_email"]
-        if not self.errors["author_name"]:
-            del self.errors["author_name"]
 
         return cleaned_data
 

--- a/src/lando/ui/legacy/forms.py
+++ b/src/lando/ui/legacy/forms.py
@@ -1,6 +1,7 @@
 from typing import Any
 
 from django import forms
+from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
 from django.forms.widgets import RadioSelect
@@ -13,14 +14,9 @@ from lando.main.models.uplift import (
     UpliftTargetSelectionMethod,
     YesNoChoices,
 )
-from lando.main.support import DISALLOWED_AUTHOR_EMAILS
 
 
 class TransplantRequestForm(forms.Form):
-    def validate_author(value):
-        if value in DISALLOWED_AUTHOR_EMAILS:
-            raise ValidationError("The email provided is not allowed")
-
     landing_path = forms.JSONField(widget=forms.widgets.HiddenInput)
     confirmation_token = forms.CharField(
         widget=forms.widgets.HiddenInput, required=False
@@ -35,8 +31,14 @@ class TransplantRequestForm(forms.Form):
     author_email = forms.EmailField(
         required=False,
         widget=forms.TextInput(attrs={"class": "input"}),
-        validators=[validate_author],
     )
+
+    def clean_author_email(self) -> str:
+        """Normalize author_email by lower-casing and stripping, then validating the value."""
+        value = self.cleaned_data.get("author_email", "").strip().lower()
+        if value in settings.DISALLOWED_AUTHOR_EMAILS:
+            raise ValidationError("The email provided is not allowed")
+        return value
 
     def clean(self) -> dict[str, Any]:
         """

--- a/src/lando/ui/legacy/revisions.py
+++ b/src/lando/ui/legacy/revisions.py
@@ -14,7 +14,7 @@ from lando.api.legacy import api as legacy_api
 from lando.api.legacy.revisions import seed_revisions_from_phabricator
 from lando.api.legacy.validation import parse_revision_ids
 from lando.main.auth import force_auth_refresh, require_phabricator_api_key
-from lando.main.models import Repo
+from lando.main.models import Profile, Repo
 from lando.main.models.jobs import JobStatus
 from lando.main.models.uplift import (
     UpliftAssessment,
@@ -22,6 +22,7 @@ from lando.main.models.uplift import (
     UpliftRevision,
     UpliftSubmission,
 )
+from lando.main.support import get_revisions_with_disallowed_authors
 from lando.ui.legacy.forms import (
     LinkUpliftAssessmentForm,
     TransplantRequestForm,
@@ -494,6 +495,30 @@ class RevisionView(LandoView):
             stack=stack["stack"],
         )
 
+        # Hackbot check
+        revisions_with_disallowed_authors = get_revisions_with_disallowed_authors(
+            revisions
+        )
+        if revisions_with_disallowed_authors:
+            # Take the first revision author, try to find an associated user in Lando.
+            # If this is not possible, set the mailbox to the name of the user, which
+            # must be modified before submitting.
+            author_phid = revisions_with_disallowed_authors[0]["author"]["phid"]
+            try:
+                lando_user = Profile.objects.get(phabricator_phid=author_phid).user
+            except Profile.DoesNotExist:
+                form.fields["author_name"].initial = revisions_with_disallowed_authors[
+                    0
+                ]["author"]["real_name"]
+            else:
+                form.fields["author_name"].initial = lando_user.profile.userinfo["name"]
+                form.fields["author_email"].initial = lando_user.profile.userinfo[
+                    "email"
+                ]
+        else:
+            form.fields["author_name"].initial = None
+            form.fields["author_email"].initial = None
+
         # Current implementation requires that all commits have the flags appended.
         # This may change in the future. What we do here is:
         # - if all commits have the flag, then disable the checkbox
@@ -534,6 +559,7 @@ class RevisionView(LandoView):
                 if landing_jobs
                 else None
             ),
+            "revisions_with_disallowed_authors": revisions_with_disallowed_authors,
         }
 
         return TemplateResponse(
@@ -559,9 +585,6 @@ class RevisionView(LandoView):
             errors.append("You must be logged in to request a landing")
 
         if form.is_valid() and not errors:
-            form.cleaned_data["landing_path"] = json.loads(
-                form.cleaned_data["landing_path"]
-            )
             form.cleaned_data["flags"] = (
                 form.cleaned_data["flags"] if form.cleaned_data["flags"] else []
             )

--- a/src/lando/ui/legacy/revisions.py
+++ b/src/lando/ui/legacy/revisions.py
@@ -1,4 +1,3 @@
-import json
 import logging
 
 from django.contrib import messages
@@ -459,8 +458,7 @@ class RevisionView(LandoView):
                 }
                 for phid in series
             ]
-            landing_path_json = json.dumps(landing_path)
-            form.fields["landing_path"].initial = landing_path_json
+            form.fields["landing_path"].initial = landing_path
 
             dryrun = legacy_api.transplants.dryrun(
                 phab, lando_user, data={"landing_path": landing_path}

--- a/src/lando/ui/tests/test_forms.py
+++ b/src/lando/ui/tests/test_forms.py
@@ -1,7 +1,11 @@
 import pytest
 from django.contrib.auth.models import User
 
-from lando.ui.legacy.forms import UpliftAssessmentLinkForm, UserSettingsForm
+from lando.ui.legacy.forms import (
+    TransplantRequestForm,
+    UpliftAssessmentLinkForm,
+    UserSettingsForm,
+)
 
 
 @pytest.mark.parametrize(
@@ -127,8 +131,6 @@ def test_uplift_assessment_link_form_revision_ids(
     ),
 )
 def test__TransplantRequestForm(data, mailbox, errors):
-    from lando.ui.legacy.forms import TransplantRequestForm
-
     form = TransplantRequestForm(data)
     if not errors:
         assert form.is_valid()

--- a/src/lando/ui/tests/test_forms.py
+++ b/src/lando/ui/tests/test_forms.py
@@ -72,3 +72,69 @@ def test_uplift_assessment_link_form_revision_ids(
     else:
         assert not form.is_valid()
         assert "revision_ids" in form.errors
+
+
+@pytest.mark.parametrize(
+    "data,mailbox,errors",
+    (
+        ({"author_name": "", "author_email": "", "landing_path": "1"}, None, None),
+        (
+            {"author_name": "test", "author_email": "", "landing_path": "1"},
+            None,
+            {"author_email": ["This field is required."]},
+        ),
+        (
+            {
+                "author_name": "",
+                "author_email": "test@example.com",
+                "landing_path": "1",
+            },
+            None,
+            {"author_name": ["This field is required."]},
+        ),
+        (
+            {"author_name": "", "author_email": "test", "landing_path": "1"},
+            None,
+            {
+                "author_email": [
+                    "Enter a valid email address.",
+                ],
+            },
+        ),
+        (
+            {
+                "author_name": "test",
+                "author_email": "test@example.com",
+                "landing_path": "1",
+            },
+            ("test", "test@example.com"),
+            None,
+        ),
+        (
+            {
+                "author_name": "test",
+                "author_email": "hackbot@mozilla.tld",
+                "landing_path": "1",
+            },
+            None,
+            {
+                "author_email": [
+                    "The email provided is not allowed",
+                    "This field is required.",
+                ]
+            },
+        ),
+    ),
+)
+def test__TransplantRequestForm(data, mailbox, errors):
+    from lando.ui.legacy.forms import TransplantRequestForm
+
+    form = TransplantRequestForm(data)
+    if not errors:
+        assert form.is_valid()
+        assert form.cleaned_data["mailbox"] == mailbox
+        if mailbox:
+            assert "author_name" not in form.cleaned_data
+            assert "author_email" not in form.cleaned_data
+    else:
+        assert form.errors == errors

--- a/src/lando/ui/tests/test_stacks.py
+++ b/src/lando/ui/tests/test_stacks.py
@@ -103,3 +103,70 @@ def test_draw_stack_graph_complex():
         {"above": [0], "below": [0], "node": "PHID-DREV-9", "other": [], "pos": 0},
         {"above": [], "below": [0], "node": "PHID-DREV-8", "other": [], "pos": 0},
     ]
+
+
+@pytest.mark.parametrize(
+    "username,email,trigger",
+    [
+        ("Hackbot", "hackbot@mozilla.tld", True),
+        ("Someone else", "test@example.org", False),
+    ],
+)
+@pytest.mark.django_db(transaction=True)
+def test_integrated_transplant_simple_partial_stack_saves_data_in_db(
+    username,
+    email,
+    trigger,
+    user,
+    authenticated_client,
+    mocked_repo_config,
+    phabdouble,
+    release_management_project,
+    needs_data_classification_project,
+    scm_user,
+):
+    author = phabdouble.user(username=username, email=email)
+    phabrepo = phabdouble.repo(name="mozilla-central")
+    reviewer = phabdouble.user(username="reviewer")
+
+    d1 = phabdouble.diff(author=author)
+    r1 = phabdouble.revision(diff=d1, repo=phabrepo)
+    phabdouble.reviewer(r1, reviewer)
+
+    data = {"landing_path": '[{"revision_id": "D1", "diff_id": 1}]'}
+    if trigger:
+        revision_author = phabdouble.api_object_for(phabdouble.user())
+        form = authenticated_client.get(f"/D{r1['id']}/").context_data["form"]
+        assert (
+            form.fields["author_name"].initial == revision_author["fields"]["realName"]
+        )
+        assert form.fields["author_email"].initial is None
+        data["confirmation_token"] = (
+            "49a7ae3b20dacee70c9e02407a3d5e80dafe7fe3ea5527a48cb43311ed078a65"
+        )
+        with pytest.raises(ValueError) as e:
+            authenticated_client.post(f"/D{r1['id']}/", data=data)
+        assert (
+            str(e.value)
+            == "Mailbox values should be present if and only if disallowed authors are persent."
+        )
+
+        # Associate Lando user with the phabricator user and try again.
+        user.profile.phabricator_phid = r1["authorPHID"]
+        user.profile.save()
+        form = authenticated_client.get(f"/D{r1['id']}/").context_data["form"]
+        assert form.fields["author_name"].initial == user.profile.userinfo["name"]
+        assert form.fields["author_email"].initial == user.profile.userinfo["email"]
+
+        data["author_name"] = form.fields["author_name"].initial
+        data["author_email"] = form.fields["author_email"].initial
+        response = authenticated_client.post(f"/D{r1['id']}/", data=data)
+        messages = list(response.wsgi_request._messages)
+        assert len(messages) == 0
+    else:
+        form = authenticated_client.get(f"/D{r1['id']}/").context_data["form"]
+        assert form.fields["author_name"].initial is None
+        assert form.fields["author_email"].initial is None
+        response = authenticated_client.post(f"/D{r1['id']}/", data=data)
+        messages = list(response.wsgi_request._messages)
+        assert len(messages) == 0

--- a/src/lando/ui/tests/test_stacks.py
+++ b/src/lando/ui/tests/test_stacks.py
@@ -1,5 +1,7 @@
 import pytest
 
+from lando.api.legacy.api.transplants import LegacyAPIException
+from lando.main.models import Revision
 from lando.ui.legacy.stacks import (
     Edge,
     draw_stack_graph,
@@ -114,7 +116,7 @@ def test_draw_stack_graph_complex():
     ],
 )
 @pytest.mark.django_db(transaction=True)
-def test_integrated_transplant_simple_partial_stack_saves_data_in_db(
+def test_transplant_disallowed_author_requires_author_override(
     username,
     email,
     trigger,
@@ -138,19 +140,20 @@ def test_integrated_transplant_simple_partial_stack_saves_data_in_db(
     data = {"landing_path": '[{"revision_id": "D1", "diff_id": 1}]'}
     if trigger:
         revision_author = phabdouble.api_object_for(r1_author)
-        form = authenticated_client.get(f"/D{r1['id']}/").context_data["form"]
+        context_data = authenticated_client.get(f"/D{r1['id']}/").context_data
+
+        form = context_data["form"]
         assert (
             form.fields["author_name"].initial == revision_author["fields"]["realName"]
         )
         assert form.fields["author_email"].initial is None
-        data["confirmation_token"] = (
-            "49a7ae3b20dacee70c9e02407a3d5e80dafe7fe3ea5527a48cb43311ed078a65"
-        )
-        with pytest.raises(ValueError) as e:
+
+        data["confirmation_token"] = context_data["dryrun"]["confirmation_token"]
+        with pytest.raises(LegacyAPIException) as e:
             authenticated_client.post(f"/D{r1['id']}/", data=data)
-        assert (
-            str(e.value)
-            == "Mailbox values should be present if and only if disallowed authors are persent."
+        assert e.value.args == (
+            400,
+            "Mailbox values should be present if and only if disallowed authors are present.",
         )
 
         # Associate Lando user with the phabricator user and try again.
@@ -164,7 +167,11 @@ def test_integrated_transplant_simple_partial_stack_saves_data_in_db(
         data["author_email"] = form.fields["author_email"].initial
         response = authenticated_client.post(f"/D{r1['id']}/", data=data)
         messages = list(response.wsgi_request._messages)
+        revision = Revision.objects.get(revision_id=r1["id"], diff_id=d1["id"])
         assert len(messages) == 0
+
+        assert revision.patch_data["author_name"] == data["author_name"]
+        assert revision.patch_data["author_email"] == data["author_email"]
     else:
         form = authenticated_client.get(f"/D{r1['id']}/").context_data["form"]
         assert form.fields["author_name"].initial is None
@@ -172,3 +179,7 @@ def test_integrated_transplant_simple_partial_stack_saves_data_in_db(
         response = authenticated_client.post(f"/D{r1['id']}/", data=data)
         messages = list(response.wsgi_request._messages)
         assert len(messages) == 0
+
+        revision = Revision.objects.get(revision_id=r1["id"], diff_id=d1["id"])
+        assert revision.patch_data["author_name"] == d1["authorName"]
+        assert revision.patch_data["author_email"] == d1["authorEmail"]

--- a/src/lando/ui/tests/test_stacks.py
+++ b/src/lando/ui/tests/test_stacks.py
@@ -109,6 +109,7 @@ def test_draw_stack_graph_complex():
     "username,email,trigger",
     [
         ("Hackbot", "hackbot@mozilla.tld", True),
+        ("Hackbot", " haCkbOt@moziLla.Tld ", True),
         ("Someone else", "test@example.org", False),
     ],
 )
@@ -125,17 +126,18 @@ def test_integrated_transplant_simple_partial_stack_saves_data_in_db(
     needs_data_classification_project,
     scm_user,
 ):
-    author = phabdouble.user(username=username, email=email)
+    r1_author = phabdouble.user()
+    d1_author = phabdouble.user(username=username, email=email)
     phabrepo = phabdouble.repo(name="mozilla-central")
     reviewer = phabdouble.user(username="reviewer")
 
-    d1 = phabdouble.diff(author=author)
+    d1 = phabdouble.diff(author=d1_author)
     r1 = phabdouble.revision(diff=d1, repo=phabrepo)
     phabdouble.reviewer(r1, reviewer)
 
     data = {"landing_path": '[{"revision_id": "D1", "diff_id": 1}]'}
     if trigger:
-        revision_author = phabdouble.api_object_for(phabdouble.user())
+        revision_author = phabdouble.api_object_for(r1_author)
         form = authenticated_client.get(f"/D{r1['id']}/").context_data["form"]
         assert (
             form.fields["author_name"].initial == revision_author["fields"]["realName"]


### PR DESCRIPTION
- add mailbox fields in legacy transplants
- add validation for mailbox in legacy endpoint and form
- add UI elements
- modify hackbot blocker to be a warning when disallowed author is detected
- pre-fill form with name and email of Lando user, if available
- pre-fill form with name from Phabricator revision author if Lando user is not available
- move some fixtures
- add various tests
- fix issue with landing_path cleaning (bug 2060918)
<!--/ -+-+- DO NOT MODIFY THIS LINE - ENTER COMMIT MESSAGE ABOVE -+-+- /-->

---

Lando: [link](https://lando.moz.tools/pulls/lando/1406/)
Bugzilla: [bug 2055953](https://bugzilla.mozilla.org/show_bug.cgi?id=2055953)

:warning: This pull request has 9 warnings.
:no_entry_sign: This pull request has 1 blocker.