### PR TITLE
generate_requirements: add --no-cooldown option, and configurable make target (bug 2060725)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,5 +79,6 @@ upgrade-npm-packages: ## upgrade-npm-packages update package-lock.json
 	$(BASE_COMMAND) npm install --before="$(shell date -I -d '7 days ago')"
 
 .PHONY: upgrade-requirements
-upgrade-requirements: ## upgrade-requirements upgrade packages in requirements.txt
-	$(BASE_COMMAND) lando generate_requirements --upgrade
+upgrade-requirements: UPGRADE_ARGS=--upgrade
+upgrade-requirements: ## upgrade-requirements upgrade packages in requirements.txt. Pass `UPGRADE_ARGS=` to the `make` call to only regenerate the file without upgrades. `--no-cooldown` Is also available.
+	$(BASE_COMMAND) lando generate_requirements $(UPGRADE_ARGS)

--- a/src/lando/utils/management/commands/generate_requirements.py
+++ b/src/lando/utils/management/commands/generate_requirements.py
@@ -19,7 +19,7 @@ class Command(BaseCommand):
             "--cooldown",
             action=argparse.BooleanOptionalAction,
             default=True,
-            help="Whether to apply a cooldown an upgrades",
+            help="Only consider packages uploaded more than 7 days ago (default)",
         )
 
     def handle(self, *args, **options):

--- a/src/lando/utils/management/commands/generate_requirements.py
+++ b/src/lando/utils/management/commands/generate_requirements.py
@@ -15,6 +15,12 @@ class Command(BaseCommand):
             action="store_true",
             help="Upgrade all packages to latest versions",
         )
+        parser.add_argument(
+            "--cooldown",
+            action=argparse.BooleanOptionalAction,
+            default=True,
+            help="Whether to apply a cooldown an upgrades",
+        )
 
     def handle(self, *args, **options):
         """Run piptools compile with relevant arguments."""
@@ -23,7 +29,6 @@ class Command(BaseCommand):
             "-m",
             "piptools",
             "compile",
-            "--pip-args=--uploaded-prior-to=P7D",
             "--generate-hashes",
             "--allow-unsafe",
             "--extra=code-quality,testing",
@@ -33,6 +38,9 @@ class Command(BaseCommand):
 
         if options["upgrade"]:
             command.append("--upgrade")
+
+        if options["cooldown"]:
+            command.append("--pip-args=--uploaded-prior-to=P7D")
 
         command.append("pyproject.toml")
 


### PR DESCRIPTION
This allows us to refresh the requirements.txt without upgrading,

    make upgrade-requirements UPGRADE_ARGS=''

or to bump a (known) dependency without cooldown,

    make upgrade-requirements UPGRADE_ARGS='--no-cooldown'
<!--/ -+-+- DO NOT MODIFY THIS LINE - ENTER COMMIT MESSAGE ABOVE -+-+- /-->

---

Lando: [link](https://lando.moz.tools/pulls/lando/1432/)
Bugzilla: [bug 2060725](https://bugzilla.mozilla.org/show_bug.cgi?id=2060725)

:warning: This pull request has 5 warnings.
:no_entry_sign: This pull request has 2 blockers.