### PR TITLE
github: return full PR description in PullRequestPatchHelper.get_commit_description (bug 2060745)

### DIFF
--- a/src/lando/main/scm/helpers.py
+++ b/src/lando/main/scm/helpers.py
@@ -187,7 +187,7 @@ class PatchHelper(ABC):
 
     @abstractmethod
     def get_commit_description(self) -> str:
-        """Returns the commit description."""
+        """Returns the full commit description."""
         raise NotImplementedError("`get_commit_description` not implemented.")
 
     @abstractmethod
@@ -285,7 +285,7 @@ class HgPatchHelper(PatchHelper):
 
     @override
     def get_commit_description(self) -> str:
-        """Returns the commit description."""
+        """Returns the full commit description."""
         commit_desc = []
 
         try:
@@ -482,7 +482,7 @@ class GitPatchHelper(PatchHelper):
 
     @override
     def get_commit_description(self) -> str:
-        """Returns the commit description."""
+        """Returns the full commit description."""
         return self.commit_message
 
     @override

--- a/src/lando/utils/github.py
+++ b/src/lando/utils/github.py
@@ -755,8 +755,15 @@ class PullRequestPatchHelper(PatchHelper):
         raise NotImplementedError("`from_bytes_io` not implemented.")
 
     def get_commit_description(self) -> str:
-        """Reconstruct the commit description from the PR metadata"""
-        return self._pr.title + "\n\n" + self._pr.commit_body
+        """Returns the full commit description."""
+        # We can't use pr.commit_message here,
+        # as it also appends a trailer with the PR URL.
+        lines = [self._pr.title]
+
+        if self._pr.commit_body:
+            lines += ["", self._pr.commit_body]
+
+        return "\n".join(lines)
 
     @override
     def get_diff(self) -> str:

--- a/src/lando/utils/github.py
+++ b/src/lando/utils/github.py
@@ -755,8 +755,8 @@ class PullRequestPatchHelper(PatchHelper):
         raise NotImplementedError("`from_bytes_io` not implemented.")
 
     def get_commit_description(self) -> str:
-        """Returns the commit description."""
-        return self.get_header("subject")
+        """Reconstruct the commit description from the PR metadata"""
+        return self._pr.title + "\n\n" + self._pr.commit_body
 
     @override
     def get_diff(self) -> str:

--- a/src/lando/utils/tests/test_github.py
+++ b/src/lando/utils/tests/test_github.py
@@ -543,8 +543,12 @@ def test_PullRequestPatchHelper(github_api_client_pr: mock.Mock):
     pr_patch_helper = PullRequestPatchHelper(pr)
 
     assert (
-        pr_patch_helper.get_commit_description()
+        pr_patch_helper.get_commit_title()
         == "WIP: test pull request with multiple commits"
+    )
+    assert (
+        pr_patch_helper.get_commit_description()
+        == "WIP: test pull request with multiple commits\n\ntest description"
     )
     assert pr_patch_helper.get_timestamp() == "1761017419"
     assert pr_patch_helper.parse_author_information() == (

--- a/src/lando/utils/tests/test_github.py
+++ b/src/lando/utils/tests/test_github.py
@@ -542,18 +542,22 @@ def test_PullRequestPatchHelper(github_api_client_pr: mock.Mock):
     # PatchHelper
     pr_patch_helper = PullRequestPatchHelper(pr)
 
-    assert (
-        pr_patch_helper.get_commit_title()
-        == "WIP: test pull request with multiple commits"
-    )
-    assert (
-        pr_patch_helper.get_commit_description()
-        == "WIP: test pull request with multiple commits\n\ntest description"
-    )
+    expected_commit_title = "WIP: test pull request with multiple commits"
+
+    assert pr_patch_helper.get_commit_title() == expected_commit_title
     assert pr_patch_helper.get_timestamp() == "1761017419"
     assert pr_patch_helper.parse_author_information() == (
         "Olivier Mehani",
         "omehani@mozilla.com",
+    )
+    assert (
+        pr_patch_helper.get_commit_description()
+        == f"{expected_commit_title}\n\ntest description"
+    ), "Commit description should be the full commit message"
+
+    pr_patch_helper._pr.commit_body = ""
+    assert pr_patch_helper.get_commit_description() == expected_commit_title, (
+        "Commit description with empty commit body should have no stray newlines"
     )
 
 


### PR DESCRIPTION

<!--/ -+-+- DO NOT MODIFY THIS LINE - ENTER COMMIT MESSAGE ABOVE -+-+- /-->

---

Lando: [link](https://lando.moz.tools/pulls/lando/1433/)
Bugzilla: [bug 2060745](https://bugzilla.mozilla.org/show_bug.cgi?id=2060745)

:warning: This pull request has 6 warnings.
:no_entry_sign: This pull request has 1 blocker.