### PR TITLE
landing_checks: return all blocking errors at once (bug 2060110)

### DIFF
--- a/src/lando/utils/landing_checks.py
+++ b/src/lando/utils/landing_checks.py
@@ -490,17 +490,17 @@ class CommitMessagesCheck(PatchCollectionCheck):
         commit_message = patch_helper.get_commit_description()
         author, _email = patch_helper.parse_author_information()
 
-        current_commit_issues = []
-
         if not commit_message:
             self.commit_message_issues.append("Revision has an empty commit message.")
             return
 
-        firstline = commit_message.splitlines()[0]
+        firstline = commit_message.partition("\n")[0]
 
         if self.ignore_bad_commit_message or "IGNORE BAD COMMIT MESSAGES" in firstline:
             self.ignore_bad_commit_message = True
             return
+
+        current_commit_issues = []
 
         # Ensure backout commit descriptions are well formed.
         if is_backout(firstline):
@@ -508,7 +508,7 @@ class CommitMessagesCheck(PatchCollectionCheck):
             if not backouts or not backouts[0]:
                 current_commit_issues.append(
                     "Revision is a backout but commit message "
-                    + f"does not indicate backed out revisions: {commit_message.partition('\n')[0]}"
+                    + f"does not indicate backed out revisions: {firstline}"
                 )
 
         # Avoid checks for the merge automation users.
@@ -519,33 +519,35 @@ class CommitMessagesCheck(PatchCollectionCheck):
         if "[PATCH" in firstline:
             current_commit_issues.append(
                 "Revision contains git-format-patch '[PATCH]' cruft. "
-                + f"Use git-format-patch -k to avoid this: {commit_message.partition('\n')[0]}"
+                + f"Use git-format-patch -k to avoid this: {firstline}"
             )
 
         if match := REPO_FLAG_RE.findall(firstline):
+            malformed = False
             for repo in match:
                 if "/" in repo:
                     current_commit_issues.append(
-                        f"Push contains commits intended to be locked to {repo} but the repo name is badly formatted. '/' is not allowed: {commit_message.partition('\n')[0]}"
+                        f"Push contains commits intended to be locked to {repo} but the repo name is badly formatted. '/' is not allowed: {firstline}"
                     )
-            if self.repo_name not in match:
+                    malformed = True
+            if not malformed and self.repo_name not in match:
                 current_commit_issues.append(
-                    f"Commit locked to a repo other than {self.repo_name}: {commit_message.partition('\n')[0]}"
+                    f"Commit locked to a repo other than {self.repo_name}: {firstline}"
                 )
 
         if INVALID_REVIEW_FLAG_RE.search(firstline):
             current_commit_issues.append(
-                f"Revision contains 'r?' in the commit message. Please use 'r=' instead: {commit_message.partition('\n')[0]}"
+                f"Revision contains 'r?' in the commit message. Please use 'r=' instead: {firstline}"
             )
 
         if firstline.lower().startswith("wip:"):
             current_commit_issues.append(
-                f"Revision seems to be marked as WIP: {commit_message.partition('\n')[0]}"
+                f"Revision seems to be marked as WIP: {firstline}"
             )
 
         if re.search(RE_DIFF, commit_message):
             current_commit_issues.append(
-                f"Suspected diff found in commit message. Please indent the diff if this is on purpose: {commit_message.partition('\n')[0]}"
+                f"Suspected diff found in commit message. Please indent the diff if this is on purpose: {firstline}"
             )
 
         if current_commit_issues:
@@ -561,11 +563,11 @@ class CommitMessagesCheck(PatchCollectionCheck):
             # Purposely ambiguous: it's ok to say "backed out rev N" or
             # "reverted to rev N-1"
             current_commit_issues.append(
-                f"Backout revision needs a bug number or a rev id: {commit_message.partition('\n')[0]}"
+                f"Backout revision needs a bug number or a rev id: {firstline}"
             )
 
         current_commit_issues.append(
-            f"Revision needs 'Bug N' or 'No bug' in the commit message: {commit_message.partition('\n')[0]}"
+            f"Revision needs 'Bug N' or 'No bug' in the commit message: {firstline}"
         )
 
         self.commit_message_issues.extend(current_commit_issues)
@@ -575,7 +577,7 @@ class CommitMessagesCheck(PatchCollectionCheck):
         if self.ignore_bad_commit_message:
             return []
 
-        return self.commit_message_issues
+        return list(self.commit_message_issues)
 
 
 @dataclass

--- a/src/lando/utils/landing_checks.py
+++ b/src/lando/utils/landing_checks.py
@@ -67,7 +67,7 @@ class PatchCheck(Check, ABC):
         """Pass the next `rs_parsepatch` diff `dict` into the check."""
 
     @abstractmethod
-    def result(self) -> str | None:
+    def result(self) -> list[str]:
         """Calculate and return the result of the check."""
 
 
@@ -139,13 +139,13 @@ class PreventPathCheckMixin(ABC):
             ):
                 self.disallowed_changes.append(filename)
 
-    def result(self) -> str | None:
+    def result(self) -> list[str]:
         """Calculate and return the result of the check."""
         if not self.disallowed_changes:
             # Return early if no disallowed changes were found.
-            return
+            return []
 
-        return self.build_error_message()
+        return [self.build_error_message()]
 
 
 @dataclass
@@ -270,16 +270,16 @@ class PreventNSPRNSSCheck(PatchCheck):
         self._prevent_nspr_check.next_diff(diff)
         self._prevent_nss_check.next_diff(diff)
 
-    def result(self) -> str | None:
+    def result(self) -> list[str]:
         """Calculate and return the result of the check."""
         if (
             not self._prevent_nspr_check.disallowed_changes
             and not self._prevent_nss_check.disallowed_changes
         ):
             # Return early if no disallowed changes were found.
-            return
+            return []
 
-        return self.build_prevent_nspr_nss_error_message()
+        return [self.build_prevent_nspr_nss_error_message()]
 
 
 @dataclass
@@ -303,10 +303,12 @@ class PreventSubmodulesCheck(PatchCheck):
         if diff["filename"] == ".gitmodules":
             self.includes_gitmodules = True
 
-    def result(self) -> str | None:
+    def result(self) -> list[str]:
         """Return an error if the `.gitmodules` file was found."""
-        if self.includes_gitmodules:
-            return "Revision introduces a Git submodule into the repository."
+        if not self.includes_gitmodules:
+            return []
+
+        return ["Revision introduces a Git submodule into the repository."]
 
 
 @dataclass
@@ -330,11 +332,14 @@ class PreventHgDirectoryCheck(PatchCheck):
         if filename.startswith(".hg/") or filename == ".hg":
             self.hg_files.append(filename)
 
-    def result(self) -> str | None:
-        if self.hg_files:
-            return "Patch attempts to modify repository metadata: " + wrap_filenames(
-                self.hg_files
-            )
+    def result(self) -> list[str]:
+        if not self.hg_files:
+            return []
+
+        return [
+            "Patch attempts to modify repository metadata: "
+            + f"{wrap_filenames(self.hg_files)}."
+        ]
 
 
 @dataclass
@@ -365,12 +370,14 @@ class PreventSymlinksCheck(PatchCheck):
         if "new" in modes and modes["new"] == self.SYMLINK_MODE:
             self.symlinked_files.append(diff["filename"])
 
-    def result(self) -> str | None:
-        if self.symlinked_files:
-            return (
-                "Revision introduces symlinks in the files "
-                f"{wrap_filenames(self.symlinked_files)}."
-            )
+    def result(self) -> list[str]:
+        if not self.symlinked_files:
+            return []
+
+        return [
+            "Revision introduces symlinks in the files "
+            + f"{wrap_filenames(self.symlinked_files)}."
+        ]
 
 
 @dataclass
@@ -394,10 +401,12 @@ class TryTaskConfigCheck(PatchCheck):
         if diff["filename"] == "try_task_config.json":
             self.includes_try_task_config = True
 
-    def result(self) -> str | None:
+    def result(self) -> list[str]:
         """Return an error if the `try_task_config.json` was found."""
-        if self.includes_try_task_config:
-            return "Revision introduces the `try_task_config.json` file."
+        if not self.includes_try_task_config:
+            return []
+
+        return ["Revision introduces the `try_task_config.json` file."]
 
 
 @dataclass
@@ -432,8 +441,8 @@ class DiffAssessor:
 
         # Collect the results from each check.
         for check in checks:
-            if issue := check.result():
-                issues.append(issue)
+            if check_issues := check.result():
+                issues.extend(check_issues)
 
         return issues
 
@@ -455,7 +464,7 @@ class PatchCollectionCheck(Check, ABC):
         """Pass the next `PatchHelper` into the check."""
 
     @abstractmethod
-    def result(self) -> str | None:
+    def result(self) -> list[str]:
         """Calculate and return the result of the check."""
 
 
@@ -481,6 +490,8 @@ class CommitMessagesCheck(PatchCollectionCheck):
         commit_message = patch_helper.get_commit_description()
         author, _email = patch_helper.parse_author_information()
 
+        current_commit_issues = []
+
         if not commit_message:
             self.commit_message_issues.append("Revision has an empty commit message.")
             return
@@ -495,11 +506,10 @@ class CommitMessagesCheck(PatchCollectionCheck):
         if is_backout(firstline):
             backouts = parse_backouts(firstline, strict=True)
             if not backouts or not backouts[0]:
-                self.commit_message_issues.append(
+                current_commit_issues.append(
                     "Revision is a backout but commit message "
-                    f"does not indicate backed out revisions: {commit_message}"
+                    + f"does not indicate backed out revisions: {commit_message.partition('\n')[0]}"
                 )
-                return
 
         # Avoid checks for the merge automation users.
         if author in {"ffxbld", "seabld", "tbirdbld", "cltbld"}:
@@ -507,41 +517,39 @@ class CommitMessagesCheck(PatchCollectionCheck):
 
         # Match against [PATCH] and [PATCH n/m].
         if "[PATCH" in firstline:
-            self.commit_message_issues.append(
-                "Revision contains git-format-patch '[PATCH]' cruft. Use "
-                f"git-format-patch -k to avoid this: {commit_message}"
+            current_commit_issues.append(
+                "Revision contains git-format-patch '[PATCH]' cruft. "
+                + f"Use git-format-patch -k to avoid this: {commit_message.partition('\n')[0]}"
             )
-            return
 
         if match := REPO_FLAG_RE.findall(firstline):
             for repo in match:
                 if "/" in repo:
-                    self.commit_message_issues.append(
-                        f"Push contains commits intended to be locked to {repo} but the repo name is badly formatted. '/' is not allowed: {commit_message}"
+                    current_commit_issues.append(
+                        f"Push contains commits intended to be locked to {repo} but the repo name is badly formatted. '/' is not allowed: {commit_message.partition('\n')[0]}"
                     )
-                    return
             if self.repo_name not in match:
-                self.commit_message_issues.append(
-                    f"Commit locked to a repo other than {self.repo_name}: {commit_message}"
+                current_commit_issues.append(
+                    f"Commit locked to a repo other than {self.repo_name}: {commit_message.partition('\n')[0]}"
                 )
-                return
 
         if INVALID_REVIEW_FLAG_RE.search(firstline):
-            self.commit_message_issues.append(
-                f"Revision contains 'r?' in the commit message. Please use 'r=' instead: {commit_message}"
+            current_commit_issues.append(
+                f"Revision contains 'r?' in the commit message. Please use 'r=' instead: {commit_message.partition('\n')[0]}"
             )
-            return
 
         if firstline.lower().startswith("wip:"):
-            self.commit_message_issues.append(
-                f"Revision seems to be marked as WIP: {commit_message}"
+            current_commit_issues.append(
+                f"Revision seems to be marked as WIP: {commit_message.partition('\n')[0]}"
             )
-            return
 
         if re.search(RE_DIFF, commit_message):
-            self.commit_message_issues.append(
-                f"Suspected diff found in commit message. Please indent the diff if this is on purpose: {commit_message}"
+            current_commit_issues.append(
+                f"Suspected diff found in commit message. Please indent the diff if this is on purpose: {commit_message.partition('\n')[0]}"
             )
+
+        if current_commit_issues:
+            self.commit_message_issues.extend(current_commit_issues)
             return
 
         if any(regex.search(firstline) for regex in ACCEPTABLE_MESSAGE_FORMAT_RES):
@@ -552,19 +560,22 @@ class CommitMessagesCheck(PatchCollectionCheck):
         if firstline.lower().startswith(("back", "revert")):
             # Purposely ambiguous: it's ok to say "backed out rev N" or
             # "reverted to rev N-1"
-            self.commit_message_issues.append(
-                f"Backout revision needs a bug number or a rev id: {commit_message}"
+            current_commit_issues.append(
+                f"Backout revision needs a bug number or a rev id: {commit_message.partition('\n')[0]}"
             )
-            return
 
-        self.commit_message_issues.append(
-            f"Revision needs 'Bug N' or 'No bug' in the commit message: {commit_message}"
+        current_commit_issues.append(
+            f"Revision needs 'Bug N' or 'No bug' in the commit message: {commit_message.partition('\n')[0]}"
         )
 
-    def result(self) -> str | None:
+        self.commit_message_issues.extend(current_commit_issues)
+
+    def result(self) -> list[str]:
         """Calculate and return the result of the check."""
-        if not self.ignore_bad_commit_message and self.commit_message_issues:
-            return ", ".join(self.commit_message_issues)
+        if self.ignore_bad_commit_message:
+            return []
+
+        return self.commit_message_issues
 
 
 @dataclass
@@ -588,11 +599,14 @@ class PreventSignedCommitsCheck(PatchCollectionCheck):
         if patch_helper.metadata.signature:
             self.signed_commits.append(patch_helper.get_commit_title())
 
-    def result(self) -> str | None:
-        if self.signed_commits:
-            return "Patch introduces one or more signed commits: " + ", ".join(
-                self.signed_commits
-            )
+    def result(self) -> list[str]:
+        if not self.signed_commits:
+            return []
+
+        return [
+            "Patch introduces one or more signed commits: "
+            + ", ".join(self.signed_commits)
+        ]
 
 
 @dataclass
@@ -627,13 +641,17 @@ class WPTSyncCheck(PatchCollectionCheck):
             if not self.WPTSYNC_ALLOWED_PATHS_RE.match(filename):
                 self.wpt_disallowed_files.append(filename)
 
-    def result(self) -> str | None:
+    def result(self) -> list[str]:
         """Return an error if the WPTSync bot touched disallowed files."""
-        if self.wpt_disallowed_files:
-            return (
+        if not self.wpt_disallowed_files:
+            return []
+
+        return [
+            (
                 "Revision has WPTSync bot making changes to disallowed files "
-                f"{wrap_filenames(self.wpt_disallowed_files)}."
+                + f"{wrap_filenames(self.wpt_disallowed_files)}."
             )
+        ]
 
 
 BMO_SKIP_HINT = "Use `SKIP_BMO_CHECK` in your commit message to push anyway."
@@ -676,44 +694,50 @@ class BugReferencesCheck(PatchCollectionCheck):
 
         self.bug_ids |= set(parse_bugs(commit_message))
 
-    def result(self) -> str | None:
+    def result(self) -> list[str]:
         """Ensure all bug numbers detected in commit messages reference public bugs."""
         if self.skip_check or not self.bug_ids:
-            return
+            return []
 
         try:
             found_bugs = search_bugs(self.bug_ids)
         except requests.exceptions.RequestException as exc:
-            return BUG_REFERENCES_BMO_ERROR_TEMPLATE.format(error=str(exc))
+            return [BUG_REFERENCES_BMO_ERROR_TEMPLATE.format(error=str(exc))]
 
         invalid_bugs = self.bug_ids - found_bugs
         if not invalid_bugs:
-            return
+            return []
 
         # Check a single bug to determine which error to return.
         bug_id = invalid_bugs.pop()
         try:
             status_code = get_status_code_for_bug(bug_id)
         except requests.exceptions.RequestException as exc:
-            return BUG_REFERENCES_BMO_ERROR_TEMPLATE.format(error=str(exc))
+            return [BUG_REFERENCES_BMO_ERROR_TEMPLATE.format(error=str(exc))]
 
         if status_code == 401:
-            return (
-                f"Your commit message references bug {bug_id}, which is currently private. To avoid "
-                "disclosing the nature of this bug publicly, please remove the affected bug ID "
-                f"from the commit message. {BMO_SKIP_HINT}"
-            )
+            return [
+                (
+                    f"Your commit message references bug {bug_id}, which is currently private. To avoid "
+                    "disclosing the nature of this bug publicly, please remove the affected bug ID "
+                    f"from the commit message. {BMO_SKIP_HINT}"
+                )
+            ]
 
         if status_code == 404:
-            return (
-                f"Your commit message references bug {bug_id}, which does not exist. "
-                f"Please check your commit message and try again. {BMO_SKIP_HINT}"
-            )
+            return [
+                (
+                    f"Your commit message references bug {bug_id}, which does not exist. "
+                    f"Please check your commit message and try again. {BMO_SKIP_HINT}"
+                )
+            ]
 
-        return (
-            f"While checking if bug {bug_id} in your commit message is a security bug, "
-            f"an error occurred and the bug could not be verified. {BMO_SKIP_HINT}"
-        )
+        return [
+            (
+                f"While checking if bug {bug_id} in your commit message is a security bug, "
+                f"an error occurred and the bug could not be verified. {BMO_SKIP_HINT}"
+            )
+        ]
 
 
 @dataclass
@@ -763,8 +787,8 @@ class PatchCollectionAssessor:
 
         # Collect the result of the push-wide checks.
         for check in checks:
-            if issue := check.result():
-                issues.append(issue)
+            if check_issues := check.result():
+                issues.extend(check_issues)
 
         return issues
 

--- a/src/lando/utils/tests/test_landing_checks.py
+++ b/src/lando/utils/tests/test_landing_checks.py
@@ -358,16 +358,15 @@ def test_check_commit_message_repolocked(
     ]
     assessor = PatchCollectionAssessor(patch_helpers=patch_helpers, repo_name="foo")
 
-    expected = []
-    if return_string:
-        expected = [return_string + commit_message]
+    check_issues = assessor.run_patch_collection_checks(
+        patch_collection_checks=[CommitMessagesCheck], patch_checks=[]
+    )
 
-    assert (
-        assessor.run_patch_collection_checks(
-            patch_collection_checks=[CommitMessagesCheck], patch_checks=[]
-        )
-        == expected
-    ), error_message
+    if return_string:
+        expected = return_string + commit_message.partition("\n")[0]
+        assert expected in check_issues, error_message
+    else:
+        assert not check_issues, error_message
 
 
 def test_check_commit_message_repolocked_multiple():
@@ -403,15 +402,12 @@ def test_check_commit_message_repolocked_multiple():
     ]
     assessor = PatchCollectionAssessor(patch_helpers=patch_helpers, repo_name="foo")
 
-    expected = []
+    expected = ""
     if return_string:
-        expected = [return_string + commit_message]
+        expected = return_string + commit_message.partition("\n")[0]
 
-    assert (
-        assessor.run_patch_collection_checks(
-            patch_collection_checks=[CommitMessagesCheck], patch_checks=[]
-        )
-        == expected
+    assert expected in assessor.run_patch_collection_checks(
+        patch_collection_checks=[CommitMessagesCheck], patch_checks=[]
     ), error_message
 
 
@@ -469,10 +465,13 @@ def test_check_prevent_dot_github():
     )
     for diff in parsed_diff:
         prevent_dot_github_check.next_diff(diff)
-    assert prevent_dot_github_check.result() == (
+
+    expected = (
         "Revision makes changes to restricted directories: GitHub workflows directory: "
-        "`.github/workflows/workflow.yaml`."
-    ), (
+        + "`.github/workflows/workflow.yaml`."
+    )
+
+    assert expected in prevent_dot_github_check.result(), (
         "Check should disallow changes to GitHub workflows without proper commit message."
     )
 
@@ -482,7 +481,7 @@ def test_check_prevent_dot_github():
     )
     for diff in parsed_diff:
         prevent_dot_github_check.next_diff(diff)
-    assert prevent_dot_github_check.result() is None, (
+    assert not prevent_dot_github_check.result(), (
         "Check should allow changes to GitHub workflows with proper commit message."
     )
 
@@ -497,10 +496,11 @@ def test_check_prevent_hg_directory():
     )
     for diff in parsed_diff:
         prevent_hg_directory_check.next_diff(diff)
-    assert (
-        prevent_hg_directory_check.result()
-        == "Patch attempts to modify repository metadata: `.hg/hgrc`"
-    ), "Check should not allow changes to .hg directory"
+
+    expected = "Patch attempts to modify repository metadata: `.hg/hgrc`."
+    assert expected in prevent_hg_directory_check.result(), (
+        "Check should not allow changes to .hg directory"
+    )
 
 
 def test_check_prevent_nspr_nss_missing_fields():
@@ -512,7 +512,7 @@ def test_check_prevent_nspr_nss_missing_fields():
     )
     for diff in parsed_diff:
         prevent_nspr_nss_check.next_diff(diff)
-    assert prevent_nspr_nss_check.result() is None, (
+    assert not prevent_nspr_nss_check.result(), (
         "Missing commit message should result in passing check."
     )
 
@@ -527,10 +527,13 @@ def test_check_prevent_nspr_nss_nss():
     )
     for diff in parsed_diff:
         prevent_nspr_nss_check.next_diff(diff)
-    assert prevent_nspr_nss_check.result() == (
+    expected = (
         "Revision makes changes to restricted directories: vendored NSS directories: "
         "`security/nss/testfile.txt`."
-    ), "Check should disallow changes to NSS without proper commit message."
+    )
+    assert expected in prevent_nspr_nss_check.result(), (
+        "Check should disallow changes to NSS without proper commit message."
+    )
 
     prevent_nspr_nss_check = PreventNSPRNSSCheck(
         email="testuser@mozilla.com",
@@ -538,7 +541,7 @@ def test_check_prevent_nspr_nss_nss():
     )
     for diff in parsed_diff:
         prevent_nspr_nss_check.next_diff(diff)
-    assert prevent_nspr_nss_check.result() is None, (
+    assert not prevent_nspr_nss_check.result(), (
         "Check should allow changes to NSS with proper commit message."
     )
 
@@ -553,10 +556,13 @@ def test_check_prevent_nspr_nss_nspr():
     )
     for diff in parsed_diff:
         prevent_nspr_nss_check.next_diff(diff)
-    assert prevent_nspr_nss_check.result() == (
+    expected = (
         "Revision makes changes to restricted directories: vendored NSPR directories: "
         "`nsprpub/testfile.txt`."
-    ), "Check should disallow changes to NSPR without proper commit message."
+    )
+    assert expected in prevent_nspr_nss_check.result(), (
+        "Check should disallow changes to NSPR without proper commit message."
+    )
 
     prevent_nspr_nss_check = PreventNSPRNSSCheck(
         email="testuser@mozilla.com",
@@ -564,7 +570,7 @@ def test_check_prevent_nspr_nss_nspr():
     )
     for diff in parsed_diff:
         prevent_nspr_nss_check.next_diff(diff)
-    assert prevent_nspr_nss_check.result() is None, (
+    assert not prevent_nspr_nss_check.result(), (
         "Check should allow changes to NSPR with proper commit message."
     )
 
@@ -581,10 +587,11 @@ def test_check_prevent_nspr_nss_combined():
     )
     for diff in parsed_diff:
         prevent_nspr_nss_check.next_diff(diff)
-    assert prevent_nspr_nss_check.result() == (
+    expected = (
         "Revision makes changes to restricted directories: vendored NSS directories: "
         "`security/nss/testfile.txt` vendored NSPR directories: `nsprpub/testfile.txt`."
-    ), (
+    )
+    assert expected in prevent_nspr_nss_check.result(), (
         "Check should disallow changes to both NSS and NSPR without proper commit message."
     )
 
@@ -594,10 +601,13 @@ def test_check_prevent_nspr_nss_combined():
     )
     for diff in parsed_diff:
         prevent_nspr_nss_check.next_diff(diff)
-    assert prevent_nspr_nss_check.result() == (
+    expected = (
         "Revision makes changes to restricted directories: "
         "vendored NSS directories: `security/nss/testfile.txt`."
-    ), "Check should allow changes to NSPR with proper commit message."
+    )
+    assert expected in prevent_nspr_nss_check.result(), (
+        "Check should allow changes to NSPR with proper commit message."
+    )
 
     prevent_nspr_nss_check = PreventNSPRNSSCheck(
         email="testuser@mozilla.com",
@@ -605,10 +615,13 @@ def test_check_prevent_nspr_nss_combined():
     )
     for diff in parsed_diff:
         prevent_nspr_nss_check.next_diff(diff)
-    assert prevent_nspr_nss_check.result() == (
+    expected = (
         "Revision makes changes to restricted directories: "
         "vendored NSPR directories: `nsprpub/testfile.txt`."
-    ), "Check should allow changes to NSPR with proper commit message."
+    )
+    assert expected in prevent_nspr_nss_check.result(), (
+        "Check should allow changes to NSPR with proper commit message."
+    )
 
     prevent_nspr_nss_check = PreventNSPRNSSCheck(
         email="testuser@mozilla.com",
@@ -616,7 +629,7 @@ def test_check_prevent_nspr_nss_combined():
     )
     for diff in parsed_diff:
         prevent_nspr_nss_check.next_diff(diff)
-    assert prevent_nspr_nss_check.result() is None, (
+    assert not prevent_nspr_nss_check.result(), (
         "Check should allow changes to NSPR with proper commit message."
     )
 
@@ -629,7 +642,7 @@ def test_check_prevent_submodules():
     for diff in parsed_diff:
         prevent_submodules_check.next_diff(diff)
 
-    assert prevent_submodules_check.result() is None, (
+    assert not prevent_submodules_check.result(), (
         "Check should pass when no submodules are introduced."
     )
 
@@ -639,11 +652,10 @@ def test_check_prevent_submodules():
     prevent_submodules_check = PreventSubmodulesCheck()
     for diff in parsed_diff:
         prevent_submodules_check.next_diff(diff)
-
-    assert (
-        prevent_submodules_check.result()
-        == "Revision introduces a Git submodule into the repository."
-    ), "Check should prevent revisions from introducing submodules."
+    expected = "Revision introduces a Git submodule into the repository."
+    assert expected in prevent_submodules_check.result(), (
+        "Check should prevent revisions from introducing submodules."
+    )
 
 
 def test_check_bug_references_public_bugs():
@@ -817,7 +829,7 @@ def test_check_try_task_config():
     for diff in parsed_diff:
         try_task_config_check.next_diff(diff)
 
-    assert try_task_config_check.result() is None, (
+    assert not try_task_config_check.result(), (
         "Check should pass when no try_task_config.json is introduced."
     )
 
@@ -827,11 +839,10 @@ def test_check_try_task_config():
     try_task_config_check = TryTaskConfigCheck()
     for diff in parsed_diff:
         try_task_config_check.next_diff(diff)
-
-    assert (
-        try_task_config_check.result()
-        == "Revision introduces the `try_task_config.json` file."
-    ), "Check should prevent revisions from adding try_task_config.json."
+    expected = "Revision introduces the `try_task_config.json` file."
+    assert expected in try_task_config_check.result(), (
+        "Check should prevent revisions from adding try_task_config.json."
+    )
 
 
 def test_landing_checks_run():
@@ -847,7 +858,7 @@ def test_landing_checks_run():
         ),
         GitPatchHelper.from_string_io(
             io.StringIO(
-                # PreventNSPRNSSCheck will get triggered.
+                # PreventNSPRNSSCheck and PreventNSPRCheck will get triggered.
                 GIT_PATCH_FILENAME_TEMPLATE.format(filename="nsprpub/testfile.txt"),
             )
         ),
@@ -855,4 +866,4 @@ def test_landing_checks_run():
 
     names_run = landing_checks.run([chk.name() for chk in ALL_CHECKS], patch_helpers)
 
-    assert len(names_run) == 4
+    assert len(names_run) == 5

--- a/src/lando/utils/tests/test_landing_checks.py
+++ b/src/lando/utils/tests/test_landing_checks.py
@@ -212,7 +212,7 @@ def test_check_commit_message_valid_message(commit_message: str, error_message: 
             "WIP revisions should be rejected.",
         ),
         (
-            "[PATCH 1/2] first part of my git patch",
+            "[PATCH 1/2] bug 1: first part of my git patch",
             (
                 "Revision contains git-format-patch '[PATCH]' cruft. "
                 "Use git-format-patch -k to avoid this: "
@@ -364,7 +364,7 @@ def test_check_commit_message_repolocked(
 
     if return_string:
         expected = return_string + commit_message.partition("\n")[0]
-        assert expected in check_issues, error_message
+        assert [expected] == check_issues, error_message
     else:
         assert not check_issues, error_message
 
@@ -858,12 +858,21 @@ def test_landing_checks_run():
         ),
         GitPatchHelper.from_string_io(
             io.StringIO(
-                # PreventNSPRNSSCheck and PreventNSPRCheck will get triggered.
+                # Both PreventNSPRNSSCheck and PreventNSPRCheck will get triggered.
+                # For now, we only use the grouped one in the Repo. See Bug 2061086.
                 GIT_PATCH_FILENAME_TEMPLATE.format(filename="nsprpub/testfile.txt"),
             )
         ),
     ]
 
+    expected = [
+        "Revision introduces the `try_task_config.json` file.",
+        "Revision makes changes to restricted directories: vendored NSPR directories: `nsprpub/testfile.txt`.",
+        "Revision makes changes to restricted directories: vendored NSPR directories: `nsprpub/testfile.txt`.",
+        "Revision needs 'Bug N' or 'No bug' in the commit message: Change things",
+        "Revision needs 'Bug N' or 'No bug' in the commit message: Change things",
+    ]
+
     names_run = landing_checks.run([chk.name() for chk in ALL_CHECKS], patch_helpers)
 
-    assert len(names_run) == 5
+    assert names_run == expected


### PR DESCRIPTION
Also, only show the first line of a commit message in errors, so as not to overwhelm the report with large repeated blocks of text. The commit title should be sufficient to identify the offending commit.
<!--/ -+-+- DO NOT MODIFY THIS LINE - ENTER COMMIT MESSAGE ABOVE -+-+- /-->

---

Lando: [link](https://lando.moz.tools/pulls/lando/1434/)
Bugzilla: [bug 2060110](https://bugzilla.mozilla.org/show_bug.cgi?id=2060110)

:warning: This pull request has 10 warnings.
:no_entry_sign: This pull request has 1 blocker.