### PR TITLE
TrainSelector: show the version dropdown with the train checkboxes (bug 2052351)

### DIFF
--- a/frontend/src/components/TrainSelector.test.ts
+++ b/frontend/src/components/TrainSelector.test.ts
@@ -53,6 +53,22 @@ function repoCheckbox(value: string): HTMLInputElement {
     )!;
 }
 
+// Set the checkboxes to exactly the given repositories, as a user clicking them
+// would, so the widget observes the resulting `change` events.
+async function checkRepos(...values: string[]): Promise<void> {
+    document
+        .querySelectorAll<HTMLInputElement>('input[name="repositories"]')
+        .forEach((checkbox) => {
+            const shouldCheck = values.includes(checkbox.value);
+            if (checkbox.checked !== shouldCheck) {
+                checkbox.checked = shouldCheck;
+                checkbox.dispatchEvent(new Event("change", { bubbles: true }));
+            }
+        });
+
+    await flushPromises();
+}
+
 function repositoriesField(): HTMLElement {
     return document.querySelector<HTMLElement>("[data-uplift-repositories]")!;
 }
@@ -74,7 +90,7 @@ afterEach(() => {
 });
 
 describe("TrainSelector", () => {
-    it("hides the manual field and offers the selectable versions after loading", async () => {
+    it("shows the version dropdown alongside the train checkboxes", async () => {
         renderRepositoriesField();
         stubFetch(BETA_SHIPPING);
 
@@ -83,38 +99,14 @@ describe("TrainSelector", () => {
 
         expect(
             repositoriesField().classList.contains("is-hidden"),
-            "Version mode should hide the server-rendered repositories field.",
-        ).toBe(true);
+            "The train checkboxes should stay visible next to the version dropdown.",
+        ).toBe(false);
 
         const options = wrapper.findAll("option").map((option) => option.text());
         expect(
             options,
             "The version dropdown should offer the beta and release versions.",
         ).toEqual(["Choose a version…", "Firefox 152", "Firefox 151"]);
-    });
-
-    it("marks the active tab with aria-selected", async () => {
-        renderRepositoriesField();
-        stubFetch(BETA_SHIPPING);
-
-        const wrapper = mount(TrainSelector, { props: { apiUrl: "/api/train" } });
-        await openModal();
-
-        const tabs = wrapper.findAll('[role="tab"]');
-        expect(
-            tabs[0].attributes("aria-selected"),
-            "The version tab starts selected.",
-        ).toBe("true");
-        expect(
-            tabs[1].attributes("aria-selected"),
-            "The train tab starts unselected.",
-        ).toBe("false");
-
-        await tabs[1].trigger("click");
-        expect(
-            tabs[1].attributes("aria-selected"),
-            "Clicking the train tab selects it.",
-        ).toBe("true");
     });
 
     it("checks the beta repository when the beta version is selected", async () => {
@@ -178,24 +170,10 @@ describe("TrainSelector", () => {
         renderRepositoriesField();
         stubFetch(BETA_SHIPPING);
 
-        const wrapper = mount(TrainSelector, { props: { apiUrl: "/api/train" } });
+        mount(TrainSelector, { props: { apiUrl: "/api/train" } });
         await openModal();
 
-        // The second tab ("Select Uplift Train") switches to manual mode.
-        await wrapper.findAll(".tabs li a")[1].trigger("click");
-        await flushPromises();
-
-        expect(
-            repositoriesField().classList.contains("is-hidden"),
-            "The train tab should reveal the server-rendered repositories field.",
-        ).toBe(false);
-
-        for (const value of ["firefox-beta", "firefox-release"]) {
-            const checkbox = repoCheckbox(value);
-            checkbox.checked = true;
-            checkbox.dispatchEvent(new Event("change", { bubbles: true }));
-        }
-        await flushPromises();
+        await checkRepos("firefox-beta", "firefox-release");
 
         expect(
             messagesText(),
@@ -205,11 +183,11 @@ describe("TrainSelector", () => {
         );
         expect(
             document.querySelectorAll("#uplift-train-messages p"),
-            "The train tab should render a single combined line.",
+            "Manually selected trains should render a single combined line.",
         ).toHaveLength(1);
     });
 
-    it("records the selection method as the user moves between modes", async () => {
+    it("records a manual selection until a version is chosen", async () => {
         renderRepositoriesField();
         stubFetch(BETA_SHIPPING);
 
@@ -218,16 +196,63 @@ describe("TrainSelector", () => {
 
         expect(
             selectionMethod(),
-            "The version tab should record a widget-version selection.",
-        ).toBe("widget_version");
+            "Checking trains without using the dropdown is a manual selection.",
+        ).toBe("widget_manual");
 
-        await wrapper.findAll(".tabs li a")[1].trigger("click");
+        await wrapper.find("select").setValue(152);
         await flushPromises();
 
         expect(
             selectionMethod(),
-            "The train tab should record a widget-manual selection.",
+            "Choosing a version should record a widget-version selection.",
+        ).toBe("widget_version");
+    });
+
+    it("records a manual selection when the version recommendation is overridden", async () => {
+        renderRepositoriesField();
+        stubFetch(BETA_SHIPPING);
+
+        const wrapper = mount(TrainSelector, { props: { apiUrl: "/api/train" } });
+        await openModal();
+
+        await wrapper.find("select").setValue(152);
+        await flushPromises();
+
+        await checkRepos("firefox-beta", "firefox-release");
+
+        expect(
+            selectionMethod(),
+            "Checking a train the version did not recommend overrides the version.",
         ).toBe("widget_manual");
+        expect(
+            messagesText(),
+            "An overridden recommendation should drop the version summary.",
+        ).not.toContain("Selected the");
+
+        await checkRepos("firefox-beta");
+
+        expect(
+            selectionMethod(),
+            "Restoring the recommended trains should record the version again.",
+        ).toBe("widget_version");
+    });
+
+    it("keeps the version selection when an unmanaged repository is added", async () => {
+        renderRepositoriesField();
+        stubFetch(BETA_SHIPPING);
+
+        const wrapper = mount(TrainSelector, { props: { apiUrl: "/api/train" } });
+        await openModal();
+
+        await wrapper.find("select").setValue(152);
+        await flushPromises();
+
+        await checkRepos("firefox-beta", "firefox-esr128");
+
+        expect(
+            selectionMethod(),
+            "An ESR branch is not managed by the widget, so the version still applies.",
+        ).toBe("widget_version");
     });
 
     it("records a server-rendered selection when the guidance request fails", async () => {
@@ -253,10 +278,6 @@ describe("TrainSelector", () => {
         await openModal();
 
         expect(
-            repositoriesField().classList.contains("is-hidden"),
-            "A failed fetch should leave the server-rendered field visible.",
-        ).toBe(false);
-        expect(
             wrapper.text(),
             "A failed fetch should explain that manual selection is needed.",
         ).toContain("Could not load release-train guidance");
@@ -271,10 +292,6 @@ describe("TrainSelector", () => {
         const wrapper = mount(TrainSelector, { props: { apiUrl: "/api/train" } });
         await openModal();
 
-        expect(
-            repositoriesField().classList.contains("is-hidden"),
-            "A malformed response should leave the server-rendered field visible.",
-        ).toBe(false);
         expect(
             wrapper.text(),
             "A malformed response should explain that manual selection is needed.",

--- a/frontend/src/components/TrainSelector.test.ts
+++ b/frontend/src/components/TrainSelector.test.ts
@@ -16,15 +16,22 @@ const BETA_SHIPPING: ReleaseSchedule = {
 
 // Render the server-side repositories field the widget reaches out to. The
 // composable finds it via `document`, independent of where the widget mounts.
-function renderRepositoriesField(): void {
+// Deployments only offer the repositories that require approval, so the
+// checkboxes are configurable.
+function renderRepositoriesField(
+    repos = ["firefox-beta", "firefox-release", "firefox-esr128"],
+): void {
+    const checkboxes = repos
+        .map(
+            (repo) =>
+                `<label><input type="checkbox" name="repositories" value="${repo}"> ${repo}</label>`,
+        )
+        .join("\n");
+
     document.body.innerHTML = `
     <button class="uplift-request-open">Request Uplift</button>
     <input type="hidden" id="id_target_selection_method" name="target_selection_method">
-    <div data-uplift-repositories>
-      <label><input type="checkbox" name="repositories" value="firefox-beta"> firefox-beta</label>
-      <label><input type="checkbox" name="repositories" value="firefox-release"> firefox-release</label>
-      <label><input type="checkbox" name="repositories" value="firefox-esr128"> firefox-esr128</label>
-    </div>
+    <div data-uplift-repositories>${checkboxes}</div>
     <div id="uplift-train-messages"></div>
   `;
 }
@@ -208,7 +215,7 @@ describe("TrainSelector", () => {
         ).toBe("widget_version");
     });
 
-    it("records a manual selection when the version recommendation is overridden", async () => {
+    it("keeps the version attribution when the recommendation is overridden", async () => {
         renderRepositoriesField();
         stubFetch(BETA_SHIPPING);
 
@@ -222,8 +229,8 @@ describe("TrainSelector", () => {
 
         expect(
             selectionMethod(),
-            "Checking a train the version did not recommend overrides the version.",
-        ).toBe("widget_manual");
+            "Adjusting the checkboxes afterwards still counts as using the dropdown.",
+        ).toBe("widget_version");
         expect(
             messagesText(),
             "An overridden recommendation should drop the version summary.",
@@ -232,8 +239,24 @@ describe("TrainSelector", () => {
         await checkRepos("firefox-beta");
 
         expect(
+            messagesText(),
+            "Restoring the recommended trains should bring the summary back.",
+        ).toContain("Selected the Beta uplift train.");
+    });
+
+    it("records the version even when no train checkbox matches it", async () => {
+        renderRepositoriesField(["firefox-esr128"]);
+        stubFetch(BETA_SHIPPING);
+
+        const wrapper = mount(TrainSelector, { props: { apiUrl: "/api/train" } });
+        await openModal();
+
+        await wrapper.find("select").setValue(152);
+        await flushPromises();
+
+        expect(
             selectionMethod(),
-            "Restoring the recommended trains should record the version again.",
+            "Attribution follows the dropdown, not which checkboxes exist.",
         ).toBe("widget_version");
     });
 

--- a/frontend/src/components/TrainSelector.vue
+++ b/frontend/src/components/TrainSelector.vue
@@ -25,13 +25,10 @@ const props = withDefaults(
 /** Current state of the API response retrieval. */
 const status = ref<"loading" | "ready" | "error">("loading");
 
-/** Current mode in the component. */
-const mode = ref<"version" | "manual">("version");
-
 /** Stored API response. */
 const schedule = ref<ReleaseSchedule | null>(null);
 
-/** Selected version in "version" mode. */
+/** Firefox version selected in the dropdown, if any. */
 const selectedVersion = ref<number | null>(null);
 
 /**
@@ -58,13 +55,39 @@ const selectedRepos = computed(() =>
         : null,
 );
 
+/** Whether the widget is allowed to tick the given repository's checkbox. */
+function isManaged(repo: string): boolean {
+    return (props.managedRepos as readonly string[]).includes(repo);
+}
+
+/**
+ * Whether the checked trains still match the ones the chosen version resolved
+ * to. Ticking an unmanaged repository (e.g. ESR) alongside the recommendation
+ * leaves the version selection in effect, while changing a managed checkbox
+ * overrides it.
+ */
+const versionSelectionApplied = computed(() => {
+    const repos = selectedRepos.value;
+    if (!repos) {
+        return false;
+    }
+
+    const recommended = new Set(repos.filter(isManaged));
+    const checked = repositories.checkedRepos.value.filter(isManaged);
+
+    return (
+        checked.length === recommended.size &&
+        checked.every((repo) => recommended.has(repo))
+    );
+});
+
 /**
  * Name the uplift train(s) the chosen version resolved to, so it is clear that
  * selecting a version also selects beta, release, or both.
  */
 const selectionSummary = computed(() => {
     const repos = selectedRepos.value;
-    if (!repos) {
+    if (!repos || !versionSelectionApplied.value) {
         return "";
     }
 
@@ -90,25 +113,21 @@ const selectionSummary = computed(() => {
 });
 
 /**
- * A single informational line for the version tab, combining which train(s)
- * were selected with where the patch will land (the same landing description
- * the train tab shows).
+ * Guidance for the repositories that are currently checked, which are the
+ * source of truth whether they were ticked by the version dropdown or by hand.
  */
-const versionMessage = computed(() => {
-    const repos = selectedRepos.value;
-    if (!repos || !schedule.value) {
-        return "";
-    }
-
-    const { landing } = summarizeRepos(repos, schedule.value);
-    return [selectionSummary.value, landing].filter(Boolean).join(" ");
-});
-
-/** Combined guidance for the manually-selected repositories. */
-const manualGuidance = computed(() =>
+const guidance = computed(() =>
     schedule.value
         ? summarizeRepos(repositories.checkedRepos.value, schedule.value)
         : { landing: "", warnings: [] },
+);
+
+/**
+ * A single informational line combining which train(s) a chosen version
+ * resolved to with where the patch will land.
+ */
+const landingMessage = computed(() =>
+    [selectionSummary.value, guidance.value.landing].filter(Boolean).join(" "),
 );
 
 /** Status line shown while the guidance loads or after it fails; empty once ready. */
@@ -123,22 +142,11 @@ const statusMessage = computed(() => {
 });
 
 /**
- * The server-rendered checkbox field is shown in manual mode, and whenever the guidance
- * is unavailable so the form remains usable.
- */
-const serverRenderedFieldVisible = computed(
-    () => status.value === "error" || mode.value === "manual",
-);
-
-watch(serverRenderedFieldVisible, (visible) => repositories.setFieldVisible(visible), {
-    immediate: true,
-});
-
-/**
  * How the target was selected, for attribution. Resolves to `server_rendered`
  * when the guidance fails (the user falls back to the raw checkboxes), and is
  * left unset while loading so the server default applies if the form is
- * submitted early.
+ * submitted early. A submission only counts as `widget_version` while the
+ * checked trains are the ones the version dropdown picked.
  */
 const targetSelectionMethod = computed<TargetSelectionMethod | null>(() => {
     if (status.value === "error") {
@@ -147,7 +155,7 @@ const targetSelectionMethod = computed<TargetSelectionMethod | null>(() => {
     if (status.value !== "ready") {
         return null;
     }
-    return mode.value === "manual" ? "widget_manual" : "widget_version";
+    return versionSelectionApplied.value ? "widget_version" : "widget_manual";
 });
 
 watch(
@@ -160,11 +168,11 @@ watch(
     { immediate: true },
 );
 
-// Reapply the recommendation whenever it changes or the user re-enters version
-// mode, so the checkboxes always reflect the chosen version.
-watch([mode, selectedRepos], () => {
-    if (mode.value === "version" && selectedRepos.value) {
-        repositories.applyManaged(selectedRepos.value, props.managedRepos);
+// Tick the recommended trains whenever the chosen version resolves to a new set
+// of repositories.
+watch(selectedRepos, (repos) => {
+    if (repos) {
+        repositories.applyManaged(repos, props.managedRepos);
     }
 });
 
@@ -191,7 +199,6 @@ async function loadSchedule(): Promise<void> {
     } catch (caught) {
         console.error("Could not load uplift train guidance.", caught);
         status.value = "error";
-        mode.value = "manual";
     }
 }
 
@@ -218,66 +225,40 @@ onUnmounted(() => {
         >
             {{ statusMessage }}
         </p>
-        <template v-else>
-            <div class="tabs">
-                <ul role="tablist" aria-label="Uplift target selection">
-                    <li :class="{ 'is-active': mode === 'version' }">
-                        <a
-                            role="tab"
-                            tabindex="0"
-                            :aria-selected="mode === 'version'"
-                            @click="mode = 'version'"
-                            @keydown.enter.prevent="mode = 'version'"
-                            @keydown.space.prevent="mode = 'version'"
-                            >Select Firefox Version</a
+        <div v-else class="field">
+            <label class="label is-small" for="uplift-version-select">
+                Firefox version
+            </label>
+            <div class="control">
+                <div class="select">
+                    <select id="uplift-version-select" v-model.number="selectedVersion">
+                        <option :value="null" disabled>Choose a version…</option>
+                        <option
+                            v-for="choice in choices"
+                            :key="choice.version"
+                            :value="choice.version"
                         >
-                    </li>
-                    <li :class="{ 'is-active': mode === 'manual' }">
-                        <a
-                            role="tab"
-                            tabindex="0"
-                            :aria-selected="mode === 'manual'"
-                            @click="mode = 'manual'"
-                            @keydown.enter.prevent="mode = 'manual'"
-                            @keydown.space.prevent="mode = 'manual'"
-                            >Select Uplift Train</a
-                        >
-                    </li>
-                </ul>
-            </div>
-            <div v-if="mode === 'version'" class="field">
-                <div class="control">
-                    <div class="select">
-                        <select v-model.number="selectedVersion">
-                            <option :value="null" disabled>Choose a version…</option>
-                            <option
-                                v-for="choice in choices"
-                                :key="choice.version"
-                                :value="choice.version"
-                            >
-                                Firefox {{ choice.version }}
-                            </option>
-                        </select>
-                    </div>
+                            Firefox {{ choice.version }}
+                        </option>
+                    </select>
                 </div>
             </div>
-        </template>
+            <p class="help">
+                Choosing a version checks the matching uplift trains below. ESR branches
+                are not covered by version selection and must be checked directly.
+            </p>
+        </div>
     </div>
 
     <!-- Guidance messages render below the selection widget (see the
        `uplift-train-messages` anchor in `uplift-form.html`). -->
     <Teleport to="#uplift-train-messages">
-        <template v-if="status === 'ready' && mode === 'version'">
-            <p v-if="versionMessage" class="help is-info">
-                {{ versionMessage }}
-            </p>
-        </template>
-        <template v-else-if="status === 'ready'">
-            <p v-if="manualGuidance.landing" class="help is-info">
-                {{ manualGuidance.landing }}
+        <template v-if="status === 'ready'">
+            <p v-if="landingMessage" class="help is-info">
+                {{ landingMessage }}
             </p>
             <p
-                v-for="warning in manualGuidance.warnings"
+                v-for="warning in guidance.warnings"
                 :key="warning"
                 class="help is-warning"
             >

--- a/frontend/src/components/TrainSelector.vue
+++ b/frontend/src/components/TrainSelector.vue
@@ -62,9 +62,9 @@ function isManaged(repo: string): boolean {
 
 /**
  * Whether the checked trains still match the ones the chosen version resolved
- * to. Ticking an unmanaged repository (e.g. ESR) alongside the recommendation
- * leaves the version selection in effect, while changing a managed checkbox
- * overrides it.
+ * to, which decides whether the version summary still describes the selection.
+ * Ticking an unmanaged repository (e.g. ESR) alongside the recommendation
+ * leaves it in effect, while changing a managed checkbox overrides it.
  */
 const versionSelectionApplied = computed(() => {
     const repos = selectedRepos.value;
@@ -145,8 +145,8 @@ const statusMessage = computed(() => {
  * How the target was selected, for attribution. Resolves to `server_rendered`
  * when the guidance fails (the user falls back to the raw checkboxes), and is
  * left unset while loading so the server default applies if the form is
- * submitted early. A submission only counts as `widget_version` while the
- * checked trains are the ones the version dropdown picked.
+ * submitted early. Touching the version dropdown counts as `widget_version`
+ * for the rest of the submission, even if the checkboxes are adjusted after.
  */
 const targetSelectionMethod = computed<TargetSelectionMethod | null>(() => {
     if (status.value === "error") {
@@ -155,7 +155,7 @@ const targetSelectionMethod = computed<TargetSelectionMethod | null>(() => {
     if (status.value !== "ready") {
         return null;
     }
-    return versionSelectionApplied.value ? "widget_version" : "widget_manual";
+    return selectedVersion.value !== null ? "widget_version" : "widget_manual";
 });
 
 watch(

--- a/frontend/src/composables/useUpliftRepositories.test.ts
+++ b/frontend/src/composables/useUpliftRepositories.test.ts
@@ -75,27 +75,6 @@ describe("useUpliftRepositories", () => {
         ).toEqual(["firefox-beta"]);
     });
 
-    it("toggles the field visibility", () => {
-        renderRepositoriesField();
-
-        const repositories = setupComposable();
-        repositories.setFieldVisible(false);
-
-        const field = document.querySelector<HTMLElement>(
-            "[data-uplift-repositories]",
-        )!;
-        expect(
-            field.classList.contains("is-hidden"),
-            "Hiding the field should add the `is-hidden` class.",
-        ).toBe(true);
-
-        repositories.setFieldVisible(true);
-        expect(
-            field.classList.contains("is-hidden"),
-            "Showing the field should remove the `is-hidden` class.",
-        ).toBe(false);
-    });
-
     it("tracks manual changes to the server-rendered checkboxes", async () => {
         renderRepositoriesField();
 

--- a/frontend/src/composables/useUpliftRepositories.ts
+++ b/frontend/src/composables/useUpliftRepositories.ts
@@ -13,9 +13,6 @@ export interface UpliftRepositories {
      * @param managed - The repositories the widget is allowed to change.
      */
     applyManaged(reposToCheck: string[], managed: string[]): void;
-
-    /** Show or hide the entire server-rendered checkbox field. */
-    setFieldVisible(visible: boolean): void;
 }
 
 /**
@@ -79,17 +76,6 @@ export function useUpliftRepositories(
         syncCheckedRepos();
     }
 
-    /**
-     * Show or hide the entire server-rendered checkbox field, leaving the inputs in place
-     * so they still submit with the form. Uses Bulma's `is-hidden` helper rather
-     * than an inline style.
-     */
-    function setFieldVisible(visible: boolean): void {
-        if (fieldElement) {
-            fieldElement.classList.toggle("is-hidden", !visible);
-        }
-    }
-
     onMounted(() => {
         repoInputs().forEach((input) => {
             input.addEventListener("change", syncCheckedRepos);
@@ -103,5 +89,5 @@ export function useUpliftRepositories(
         });
     });
 
-    return { checkedRepos, applyManaged, setFieldVisible };
+    return { checkedRepos, applyManaged };
 }

--- a/src/lando/main/models/uplift.py
+++ b/src/lando/main/models/uplift.py
@@ -44,10 +44,11 @@ class UpliftTargetSelectionMethod(models.TextChoices):
     """How the uplift target repositories were selected at submission time."""
 
     # The user chose a Firefox version in the Vue widget, which resolved to the
-    # target train(s).
+    # target train(s). The train checkboxes may have been adjusted afterwards.
     WIDGET_VERSION = "widget_version", "Widget (version)"
 
-    # The user selected the target train(s) directly in the Vue widget.
+    # The Vue widget loaded, but the user checked the target train(s) directly
+    # without ever choosing a Firefox version.
     WIDGET_MANUAL = "widget_manual", "Widget (manual)"
 
     # The server-rendered checkboxes were used directly, e.g. with JavaScript

--- a/src/lando/ui/jinja2/stack/partials/uplift-form.html
+++ b/src/lando/ui/jinja2/stack/partials/uplift-form.html
@@ -72,11 +72,13 @@
                     {# Hidden field the Vue widget populates to record how the
                        target was selected; stays empty without the widget. #}
                     {{ uplift.request_form.target_selection_method }}
-                    {# Vue train-selector widget mounts here and progressively
-                       enhances the repository checkboxes below. #}
+                    {# Vue train-selector widget mounts here, rendering a Firefox
+                       version dropdown above the repository checkboxes and
+                       ticking the trains that version resolves to. #}
                     <div id="uplift-train-selector"
                          data-train-api-url="{{ uplift.train_api_url }}"></div>
                     <div class="field mt-4" data-uplift-repositories>
+                        <label class="label is-small">Uplift trains</label>
                         <div class="field is-grouped is-grouped-multiline m-0">
                             {% for checkbox in uplift.request_form.repositories %}
                                 <p class="control">


### PR DESCRIPTION
The version widget and the train checkboxes lived behind separate tabs, which
hid the checkboxes while a version was chosen and made ESR branches look
unavailable. Render the dropdown above the checkboxes instead, and derive the
recorded selection method from whether the checked trains still match the ones
the chosen version resolved to.
<!--/ -+-+- DO NOT MODIFY THIS LINE - ENTER COMMIT MESSAGE ABOVE -+-+- /-->

---

Lando: [link](https://lando.moz.tools/pulls/lando/1435/)
Bugzilla: [bug 2052351](https://bugzilla.mozilla.org/show_bug.cgi?id=2052351)

:warning: This pull request has 4 warnings.
:no_entry_sign: This pull request has 1 blocker.