### PR TITLE
bmo: use the shared HTTP user agent (Bug 2061056)

### DIFF
--- a/src/lando/api/legacy/bmo.py
+++ b/src/lando/api/legacy/bmo.py
@@ -25,7 +25,7 @@ def api_request(
     url = f"{settings.BUGZILLA_URL}/rest/{path}"
 
     common_headers = {
-        "User-Agent": "Lando-API",
+        "User-Agent": settings.HTTP_USER_AGENT,
     }
     if headers:
         common_headers.update(headers)

--- a/src/lando/api/tests/test_bmo.py
+++ b/src/lando/api/tests/test_bmo.py
@@ -8,8 +8,8 @@ def test_api_request_sends_configured_user_agent():
     with requests_mock.mock() as mocker:
         mocker.get(f"{settings.BUGZILLA_URL}/rest/bug", json={"bugs": []})
 
-        api_request("GET", "bug")
+        response = api_request("GET", "bug")
 
-        assert mocker.last_request.headers["User-Agent"] == settings.HTTP_USER_AGENT, (
+        assert response.request.headers["User-Agent"] == settings.HTTP_USER_AGENT, (
             "`api_request` should send the `HTTP_USER_AGENT` from settings."
         )

--- a/src/lando/api/tests/test_bmo.py
+++ b/src/lando/api/tests/test_bmo.py
@@ -1,0 +1,15 @@
+import requests_mock
+from django.conf import settings
+
+from lando.api.legacy.bmo import api_request
+
+
+def test_api_request_sends_configured_user_agent():
+    with requests_mock.mock() as mocker:
+        mocker.get(f"{settings.BUGZILLA_URL}/rest/bug", json={"bugs": []})
+
+        api_request("GET", "bug")
+
+        assert mocker.last_request.headers["User-Agent"] == settings.HTTP_USER_AGENT, (
+            "`api_request` should send the `HTTP_USER_AGENT` from settings."
+        )


### PR DESCRIPTION

<!--/ -+-+- DO NOT MODIFY THIS LINE - ENTER COMMIT MESSAGE ABOVE -+-+- /-->

---

Lando: [link](https://lando.moz.tools/pulls/lando/1436/)
Bugzilla: [bug 2061056](https://bugzilla.mozilla.org/show_bug.cgi?id=2061056)

:warning: This pull request has 4 warnings.
:no_entry_sign: This pull request has 2 blockers.