### PR TITLE
api.support: rename get_list -> get_stack_landing_jobs (bug 1909722)

### DIFF
--- a/src/lando/api/support.py
+++ b/src/lando/api/support.py
@@ -381,8 +381,10 @@ def submit_landing_job(phab: PhabricatorClient, user: User, data: dict) -> Landi
     return job
 
 
-def get_list(phab: PhabricatorClient, stack_revision_id: str) -> list[LandingJob]:
-    """Return a list of landing jobs related to the revision."""
+def get_stack_landing_jobs(
+    phab: PhabricatorClient, stack_revision_id: str
+) -> list[LandingJob]:
+    """Return a QuerySet of landing jobs related to the revision."""
     revision_id_int = revision_id_to_int(stack_revision_id)
 
     revision = phab.call_conduit(

--- a/src/lando/api/tests/test_transplants.py
+++ b/src/lando/api/tests/test_transplants.py
@@ -24,7 +24,7 @@ from lando.api.legacy.transplants import (
     warning_revision_secure,
     warning_wip_commit_message,
 )
-from lando.api.support import dryrun, get_list, submit_landing_job
+from lando.api.support import dryrun, get_stack_landing_jobs, submit_landing_job
 from lando.api.tests.mocks import PhabricatorDouble
 from lando.main.models import (
     JobStatus,
@@ -336,7 +336,7 @@ def test_get_transplants_for_entire_stack(phabdouble, make_landing_job, repo_mc)
         status=JobStatus.LANDED,
     )
 
-    result = get_list(
+    result = get_stack_landing_jobs(
         phabdouble.get_phabricator_client(), stack_revision_id=f"D{r2['id']}"
     )
     assert len(result) == 4
@@ -362,7 +362,7 @@ def test_get_transplant_from_middle_revision(phabdouble, make_landing_job):
         status=JobStatus.FAILED,
     )
 
-    result = get_list(
+    result = get_stack_landing_jobs(
         phabdouble.get_phabricator_client(), stack_revision_id=f"D{r2['id']}"
     )
     assert len(result) == 1
@@ -381,7 +381,9 @@ def test_get_transplant_not_authorized_to_view_revision(
     )
 
     with pytest.raises(LegacyAPIException) as exc_info:
-        get_list(phabdouble.get_phabricator_client(), stack_revision_id="D1")
+        get_stack_landing_jobs(
+            phabdouble.get_phabricator_client(), stack_revision_id="D1"
+        )
     assert exc_info.value.status == 404
 
 

--- a/src/lando/ui/views.py
+++ b/src/lando/ui/views.py
@@ -7,7 +7,7 @@ from django.utils.decorators import method_decorator
 from django.views import View
 
 from lando.api.legacy import api as legacy_api
-from lando.api.support import dryrun, get_list, submit_landing_job
+from lando.api.support import dryrun, get_stack_landing_jobs, submit_landing_job
 from lando.main.auth import force_auth_refresh, require_phabricator_api_key
 from lando.main.models import JobStatus, LandingJob, Profile, Repo
 from lando.main.support import get_revisions_with_disallowed_authors
@@ -58,7 +58,7 @@ class RevisionView(LandoView):
             )
 
         # Request all previous landing jobs for the stack.
-        landing_jobs = get_list(phab, f"D{revision_id}")
+        landing_jobs = get_stack_landing_jobs(phab, f"D{revision_id}")
 
         # The revision may appear in many `landable_paths`` if it has
         # multiple children, or any of its landable descendents have


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>