### PR TITLE
api.phabricator: rename "get" and move to proper module (bug 1909722)

### DIFF
--- a/src/lando/api/legacy/api/__init__.py
+++ b/src/lando/api/legacy/api/__init__.py
@@ -1,3 +1,0 @@
-from lando.api.legacy.api import stacks
-
-__all__ = ["stacks"]

--- a/src/lando/api/phabricator.py
+++ b/src/lando/api/phabricator.py
@@ -48,7 +48,7 @@ logger = logging.getLogger(__name__)
 HTTP_404_STRING = "Revision does not exist or you do not have permission to view it"
 
 
-def get(phab: PhabricatorClient, revision_id: int) -> dict[str, Any]:
+def get_revision_stack(phab: PhabricatorClient, revision_id: int) -> dict[str, Any]:
     """Get the stack a revision is part of.
 
     Args:

--- a/src/lando/api/support.py
+++ b/src/lando/api/support.py
@@ -6,7 +6,6 @@ import kombu
 from django.conf import settings
 from django.contrib.auth.models import User
 
-from lando.api.legacy.api.stacks import HTTP_404_STRING
 from lando.api.legacy.commit_message import format_commit_message
 from lando.api.legacy.projects import (
     CHECKIN_PROJ_SLUG,
@@ -47,6 +46,7 @@ from lando.api.legacy.validation import (
     parse_landing_path,
     revision_id_to_int,
 )
+from lando.api.phabricator import HTTP_404_STRING
 from lando.main.models import (
     JobStatus,
     LandingJob,

--- a/src/lando/api/tests/test_revisions.py
+++ b/src/lando/api/tests/test_revisions.py
@@ -1,6 +1,5 @@
 import pytest
 
-from lando.api.legacy.api import stacks
 from lando.api.legacy.revisions import (
     blocker_diff_author_is_known,
     ensure_revisions_from_phabricator,
@@ -10,6 +9,7 @@ from lando.api.legacy.revisions import (
     revision_needs_testing_tag,
 )
 from lando.api.legacy.transplants import warning_diff_author_is_hackbot
+from lando.api.phabricator import get_revision_stack
 from lando.main.models.revision import Revision
 
 pytestmark = pytest.mark.usefixtures("docker_env_vars")
@@ -77,7 +77,7 @@ def test_secure_api_flag_on_public_revision_is_false(
     public_project = phabdouble.project("public")
     revision = phabdouble.revision(projects=[public_project], repo=repo)
 
-    result = stacks.get(phabdouble.get_phabricator_client(), revision["id"])
+    result = get_revision_stack(phabdouble.get_phabricator_client(), revision["id"])
     response_revision = result["revisions"].pop()
     assert not response_revision["is_secure"]
 
@@ -93,7 +93,7 @@ def test_secure_api_flag_on_secure_revision_is_true(
     repo = phabdouble.repo(name="test-repo")
     revision = phabdouble.revision(projects=[secure_project], repo=repo)
 
-    result = stacks.get(phabdouble.get_phabricator_client(), revision["id"])
+    result = get_revision_stack(phabdouble.get_phabricator_client(), revision["id"])
     response_revision = result["revisions"].pop()
     assert response_revision["is_secure"]
 

--- a/src/lando/api/tests/test_stacks.py
+++ b/src/lando/api/tests/test_stacks.py
@@ -1,7 +1,6 @@
 import pytest
 from django.http import Http404
 
-from lando.api.legacy.api import stacks
 from lando.api.legacy.stacks import (
     RevisionStack,
     build_stack_graph,
@@ -12,6 +11,7 @@ from lando.api.legacy.transplants import (
     build_stack_assessment_state,
     run_landing_checks,
 )
+from lando.api.phabricator import get_revision_stack
 from lando.main.models import Repo
 from lando.utils.phabricator import PhabricatorRevisionStatus
 
@@ -808,7 +808,7 @@ def test_integrated_stack_endpoint_simple(
     r3 = phabdouble.revision(repo=repo, depends_on=[r1])
     r4 = phabdouble.revision(repo=unsupported_repo, depends_on=[r2, r3])
 
-    result = stacks.get(phabdouble.get_phabricator_client(), r3["id"])
+    result = get_revision_stack(phabdouble.get_phabricator_client(), r3["id"])
 
     assert len(result["edges"]) == 4
     assert (r2["phid"], r1["phid"]) in result["edges"]
@@ -848,7 +848,7 @@ def test_integrated_stack_endpoint_repos(
     r3 = phabdouble.revision(repo=repo, depends_on=[r1])
     r4 = phabdouble.revision(repo=unsupported_repo, depends_on=[r2, r3])
 
-    result = stacks.get(phabdouble.get_phabricator_client(), r4["id"])
+    result = get_revision_stack(phabdouble.get_phabricator_client(), r4["id"])
 
     assert len(result["repositories"]) == 2
 
@@ -879,7 +879,9 @@ def test_integrated_stack_has_revision_security_status(
         repo=repo, projects=[secure_project], depends_on=[public_revision]
     )
 
-    result = stacks.get(phabdouble.get_phabricator_client(), secure_revision["id"])
+    result = get_revision_stack(
+        phabdouble.get_phabricator_client(), secure_revision["id"]
+    )
 
     revisions = {r["phid"]: r for r in result["revisions"]}
     assert not revisions[public_revision["phid"]]["is_secure"]
@@ -904,7 +906,7 @@ def test_integrated_stack_response_mismatch_returns_404(
     r2 = phabdouble.revision(repo=repo, depends_on=[r1])
 
     phab = phabdouble.get_phabricator_client()
-    result = stacks.get(phab, r1["id"])
+    result = get_revision_stack(phab, r1["id"])
     assert len(result["edges"]) == 1
     assert len(result["revisions"]) == 2
 
@@ -914,12 +916,12 @@ def test_integrated_stack_response_mismatch_returns_404(
     ]
 
     with pytest.raises(Http404):
-        stacks.get(phab, r1["id"])
+        get_revision_stack(phab, r1["id"])
 
     # Remove dependency on r2.
     phabdouble.update_revision_dependencies(r1["phid"], [])
 
-    result = stacks.get(phab, r1["id"])
+    result = get_revision_stack(phab, r1["id"])
     assert len(result["edges"]) == 0
     assert len(result["revisions"]) == 1
 

--- a/src/lando/ui/views.py
+++ b/src/lando/ui/views.py
@@ -6,7 +6,7 @@ from django.template.response import TemplateResponse
 from django.utils.decorators import method_decorator
 from django.views import View
 
-from lando.api.legacy import api as legacy_api
+from lando.api.phabricator import get_revision_stack
 from lando.api.support import dryrun, get_stack_landing_jobs, submit_landing_job
 from lando.main.auth import force_auth_refresh, require_phabricator_api_key
 from lando.main.models import JobStatus, LandingJob, Profile, Repo
@@ -35,7 +35,7 @@ class RevisionView(LandoView):
         lando_user = request.user
 
         # This is added for backwards compatibility.
-        stack = legacy_api.stacks.get(phab, revision_id)
+        stack = get_revision_stack(phab, revision_id)
 
         form = TransplantRequestForm()
         errors = []


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>